### PR TITLE
[T2.8] Add live backend connection and reconnection state management

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -596,12 +596,15 @@ cargo test --test e2e_mock_gateway
 dx serve --web --fullstack --addr 127.0.0.1 --port 4127 --open false
 ```
 
+If any test is failing or hanging, stop and repair the test or the implementation before committing. Do not commit code while knowingly leaving the suite broken.
+
 If the change affects UI presentation, do a manual live-data visual pass after the automated checks by capturing and inspecting screenshots yourself.
 
 Expectations before commit:
 
 - code is formatted
 - warnings are removed, not ignored
+- all relevant tests pass before commit; repair broken tests instead of working around them
 - the mock-gateway integration test passes
 - the app is verified to start successfully with `dx serve --web --fullstack`
 - UI changes get a manual screenshot-based visual check against the live app before commit

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -734,6 +734,7 @@ dependencies = [
  "dioxus-ssr",
  "futures-util",
  "gloo-timers",
+ "libc",
  "serde",
  "serde_json",
  "serial_test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ optional = true
 dioxus-history = "0.7.3"
 dioxus-router = "0.7.3"
 dioxus-ssr = "0.7.3"
+libc = "0.2"
 serial_test = "3"
 tempfile = "3"
 tungstenite = "0.28"

--- a/docs/milestones/proof-of-concept-1/poc_v1_task_breakdown.md
+++ b/docs/milestones/proof-of-concept-1/poc_v1_task_breakdown.md
@@ -472,6 +472,46 @@ Tests:
 
 ---
 
+## T2.9 Introduce the shared `AppClient` boundary
+
+Purpose:
+
+- introduce one shared UI-facing `AppClient` boundary so the current web app stops depending directly on server-function details and the backend contract is prepared cleanly for future native clients
+
+Output:
+
+- one shared `AppClient` interface for request-response reads
+- stable explicit endpoint paths for the current Dioxus server functions
+- a clear separation between UI-facing client code, server-function transport, and backend app-service logic
+
+Initial scope:
+
+- cover `get_gateway_status()`
+- cover `get_agent_overview()` only if it follows the same shape cleanly
+- keep live transport out of scope except where stable endpoint naming or client setup affects future work
+
+Delivery rules:
+
+- keep the web app calling through Dioxus server functions underneath `AppClient`
+- keep UI components unaware of gateway protocol and transport details
+- keep `AppClient` small and focused on the current read paths
+- do not collapse `AppClient` into the deeper `GatewayAdapter`; they solve different layers of the architecture
+- prefer explicit stable endpoint annotations for the relevant server functions so future native clients are not coupled to unstable generated paths
+
+Tests:
+
+- unit test: the web `AppClient` delegates to the existing server-function-backed path for gateway status
+- unit test: shared UI-facing code can depend on `AppClient` without importing transport-specific or OpenClaw-specific types
+- unit test: error mapping at the `AppClient` boundary preserves the current operator-facing degraded semantics
+- compile test: UI-facing code depends only on shared models and the `AppClient` interface, not on OpenClaw-specific transport code
+- integration test: existing server functions still return the same typed payloads for the web `AppClient`
+- integration test: dashboard route still renders the expected gateway status states through the web `AppClient`
+- integration test: agents route still renders the expected overview state if `get_agent_overview()` is included in this task
+- integration test: the relevant server functions expose explicit stable endpoint paths suitable for both web and desktop callers
+- live verification: confirm the running web app still loads dashboard and agents through the web `AppClient`, and verify the stable endpoint design is ready for future native-client use without changing the UI-facing boundary
+
+---
+
 # Phase 3: OpenClaw Adapter Minimum Slice
 
 ## T3.1 Create the adapter trait and OpenClaw adapter module

--- a/src/components/layout.rs
+++ b/src/components/layout.rs
@@ -2,22 +2,70 @@
 
 use dioxus::prelude::*;
 
-use crate::components::{navbar::TopBar, sidebar::Sidebar};
+use crate::components::{
+    live_gateway::{LiveGatewayProvider, use_live_gateway},
+    navbar::TopBar,
+    sidebar::Sidebar,
+};
 use crate::router::Route;
 
 #[component]
 pub fn AppLayout() -> Element {
     rsx! {
-        div { class: "min-h-screen bg-[var(--app-bg)] text-[var(--ink-0)]",
-            div { class: "grid min-h-screen grid-cols-1 lg:grid-cols-[15.5rem_minmax(0,1fr)]",
-                Sidebar {}
-                div { class: "min-w-0",
-                TopBar {}
-                    main { class: "px-5 pb-8 pt-6 sm:px-8 lg:px-10",
-                        Outlet::<Route> {}
-                    }
+        LiveGatewayProvider {
+            div { class: "min-h-screen bg-[var(--app-bg)] text-[var(--ink-0)]",
+                div { class: "grid min-h-screen grid-cols-1 lg:grid-cols-[15.5rem_minmax(0,1fr)]",
+                    Sidebar {}
+                    LayoutContent {}
                 }
             }
         }
+    }
+}
+
+#[component]
+fn LayoutContent() -> Element {
+    let live_gateway = use_live_gateway();
+    let main_class = main_content_class(live_gateway.is_frozen());
+
+    rsx! {
+        div { class: "min-w-0",
+            TopBar {}
+            main { class: main_class,
+                Outlet::<Route> {}
+                if live_gateway.is_frozen() {
+                    p { class: "mt-4 text-xs uppercase tracking-[0.2em] text-slate-400", "Live updates paused while reconnecting to the backend" }
+                }
+            }
+        }
+    }
+}
+
+fn main_content_class(is_frozen: bool) -> &'static str {
+    if is_frozen {
+        "px-5 pb-8 pt-6 opacity-75 grayscale-[0.18] saturate-[0.8] transition-[opacity,filter] duration-300 sm:px-8 lg:px-10"
+    } else {
+        "px-5 pb-8 pt-6 transition-[opacity,filter] duration-300 sm:px-8 lg:px-10"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::main_content_class;
+
+    #[test]
+    fn frozen_layout_uses_subdued_class() {
+        let class = main_content_class(true);
+
+        assert!(class.contains("opacity-75"));
+        assert!(class.contains("grayscale"));
+    }
+
+    #[test]
+    fn live_layout_keeps_normal_class() {
+        let class = main_content_class(false);
+
+        assert!(!class.contains("opacity-75"));
+        assert!(!class.contains("grayscale"));
     }
 }

--- a/src/components/live_gateway.rs
+++ b/src/components/live_gateway.rs
@@ -2,11 +2,48 @@
 
 use dioxus::prelude::*;
 
-use crate::models::live_gateway::LiveGatewayEvent;
+#[cfg(target_arch = "wasm32")]
+use crate::models::live_gateway::LiveGatewayLevel;
+use crate::models::live_gateway::{
+    BackendConnectionState, LiveGatewayEvent, OperatorConnectionState,
+    resolve_operator_connection_state,
+};
 
-pub(crate) fn use_live_gateway_events() -> (Signal<Option<LiveGatewayEvent>>, Signal<bool>) {
+#[derive(Clone, Copy)]
+pub(crate) struct LiveGatewayState {
+    pub live_status: Signal<Option<LiveGatewayEvent>>,
+    pub backend_state: Signal<BackendConnectionState>,
+}
+
+impl LiveGatewayState {
+    pub fn operator_state(&self) -> OperatorConnectionState {
+        resolve_operator_connection_state(
+            (self.backend_state)(),
+            (self.live_status)().map(|event| event.level),
+        )
+    }
+
+    pub fn is_frozen(&self) -> bool {
+        (self.backend_state)() == BackendConnectionState::Disconnected
+    }
+}
+
+#[component]
+pub fn LiveGatewayProvider(children: Element) -> Element {
+    let live_gateway = use_live_gateway_state();
+    use_context_provider(|| live_gateway);
+
+    rsx! { {children} }
+}
+
+pub(crate) fn use_live_gateway() -> LiveGatewayState {
+    use_context::<LiveGatewayState>()
+}
+
+fn use_live_gateway_state() -> LiveGatewayState {
     let live_status = use_signal(|| None::<LiveGatewayEvent>);
-    let live_seen = use_signal(|| false);
+    let backend_state = use_signal(|| initial_backend_connection_state());
+    let _ = non_wasm_reconnect_state_sentinel();
 
     #[cfg(target_arch = "wasm32")]
     let mut live_listener_attached = use_signal(|| false);
@@ -17,19 +54,39 @@ pub(crate) fn use_live_gateway_events() -> (Signal<Option<LiveGatewayEvent>>, Si
             attach_live_gateway_listener(
                 &mut live_listener_attached,
                 live_status.clone(),
-                live_seen.clone(),
+                backend_state.clone(),
             );
         });
     }
 
-    (live_status, live_seen)
+    LiveGatewayState {
+        live_status,
+        backend_state,
+    }
+}
+
+fn initial_backend_connection_state() -> BackendConnectionState {
+    if cfg!(target_arch = "wasm32") {
+        BackendConnectionState::Connecting
+    } else {
+        BackendConnectionState::Connected
+    }
+}
+
+fn non_wasm_reconnect_state_sentinel() -> Option<BackendConnectionState> {
+    if cfg!(target_arch = "wasm32") {
+        None
+    } else {
+        // Keep SSR/test builds aware of the reconnecting state without changing runtime behavior.
+        Some(BackendConnectionState::Connecting)
+    }
 }
 
 #[cfg(target_arch = "wasm32")]
 fn attach_live_gateway_listener(
     live_listener_attached: &mut Signal<bool>,
     live_status: Signal<Option<LiveGatewayEvent>>,
-    live_seen: Signal<bool>,
+    backend_state: Signal<BackendConnectionState>,
 ) {
     use web_sys::wasm_bindgen::{JsCast, closure::Closure};
 
@@ -43,7 +100,7 @@ fn attach_live_gateway_listener(
 
     let onmessage = Closure::<dyn FnMut(web_sys::MessageEvent)>::new({
         let mut live_status = live_status.clone();
-        let mut live_seen = live_seen.clone();
+        let mut backend_state = backend_state.clone();
         move |event: web_sys::MessageEvent| {
             if let Some(parsed) = event
                 .data()
@@ -51,19 +108,35 @@ fn attach_live_gateway_listener(
                 .and_then(|text| serde_json::from_str::<LiveGatewayEvent>(&text).ok())
             {
                 live_status.set(Some(parsed));
-                live_seen.set(true);
+                backend_state.set(BackendConnectionState::Connected);
             }
         }
     });
     event_source.set_onmessage(Some(onmessage.as_ref().unchecked_ref()));
     onmessage.forget();
 
+    let onopen = Closure::<dyn FnMut(web_sys::Event)>::new({
+        let mut backend_state = backend_state.clone();
+        let mut live_status = live_status.clone();
+        move |_| {
+            backend_state.set(BackendConnectionState::Connected);
+            if matches!(
+                live_status.peek().as_ref().map(|event| event.level),
+                None | Some(LiveGatewayLevel::Disconnected)
+            ) {
+                live_status.set(Some(connecting_event()));
+            }
+        }
+    });
+    event_source.set_onopen(Some(onopen.as_ref().unchecked_ref()));
+    onopen.forget();
+
     let onerror = Closure::<dyn FnMut(web_sys::Event)>::new({
         let mut live_status = live_status.clone();
-        let mut live_seen = live_seen.clone();
+        let mut backend_state = backend_state.clone();
         move |_| {
-            live_status.set(Some(connecting_event()));
-            live_seen.set(false);
+            backend_state.set(BackendConnectionState::Disconnected);
+            live_status.set(Some(disconnected_event()));
         }
     });
     event_source.set_onerror(Some(onerror.as_ref().unchecked_ref()));
@@ -82,8 +155,18 @@ fn live_stream_enabled() -> bool {
 #[cfg(target_arch = "wasm32")]
 fn connecting_event() -> LiveGatewayEvent {
     LiveGatewayEvent {
-        level: crate::models::live_gateway::LiveGatewayLevel::Connecting,
+        level: LiveGatewayLevel::Connecting,
         summary: "Gateway event stream reconnecting.".to_string(),
         detail: "The browser will retry the live event stream automatically.".to_string(),
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn disconnected_event() -> LiveGatewayEvent {
+    LiveGatewayEvent {
+        level: LiveGatewayLevel::Disconnected,
+        summary: "Backend event stream disconnected.".to_string(),
+        detail: "The browser is keeping the current view frozen while it retries the backend."
+            .to_string(),
     }
 }

--- a/src/components/navbar.rs
+++ b/src/components/navbar.rs
@@ -2,19 +2,25 @@
 
 use dioxus::prelude::*;
 
-use crate::components::live_gateway::use_live_gateway_events;
+use crate::components::live_gateway::use_live_gateway;
 use crate::gateway::get_gateway_status;
 use crate::models::gateway::GatewayLevel;
-use crate::models::live_gateway::{LiveGatewayEvent, LiveGatewayLevel};
+use crate::models::live_gateway::{
+    LiveGatewayLevel, OperatorConnectionState, resolve_operator_connection_state,
+};
 
 #[component]
 pub fn TopBar() -> Element {
     let gateway_status = use_resource(|| async move { get_gateway_status().await });
-    let (live_status, live_seen) = use_live_gateway_events();
+    let live_gateway = use_live_gateway();
 
-    let pill = status_pill(resolved_live_level(&gateway_status, live_status()));
+    let pill = status_pill(resolved_live_level(&gateway_status, &live_gateway));
 
-    let live_attr = if live_seen() { "true" } else { "false" };
+    let live_attr = if live_gateway.operator_state() == OperatorConnectionState::Connected {
+        "true"
+    } else {
+        "false"
+    };
 
     rsx! {
         header { class: "flex flex-col gap-5 px-5 pt-6 sm:px-8 lg:flex-row lg:items-center lg:justify-between lg:px-10",
@@ -39,8 +45,8 @@ pub fn TopBar() -> Element {
 
 fn resolved_live_level(
     gateway_status: &Resource<Result<crate::models::gateway::GatewayStatusSnapshot, ServerFnError>>,
-    live_status: Option<LiveGatewayEvent>,
-) -> Option<LiveGatewayLevel> {
+    live_gateway: &crate::components::live_gateway::LiveGatewayState,
+) -> OperatorConnectionState {
     let gateway_level = gateway_status
         .read_unchecked()
         .as_ref()
@@ -50,19 +56,12 @@ fn resolved_live_level(
             GatewayLevel::Degraded => LiveGatewayLevel::Degraded,
         });
 
-    combine_gateway_levels(gateway_level, live_status.map(|event| event.level))
-}
-
-fn combine_gateway_levels(
-    gateway_level: Option<LiveGatewayLevel>,
-    live_level: Option<LiveGatewayLevel>,
-) -> Option<LiveGatewayLevel> {
-    match live_level {
-        Some(LiveGatewayLevel::Healthy) => Some(LiveGatewayLevel::Healthy),
-        Some(LiveGatewayLevel::Degraded) => Some(LiveGatewayLevel::Degraded),
-        Some(LiveGatewayLevel::Connecting) => gateway_level.or(Some(LiveGatewayLevel::Connecting)),
-        None => gateway_level,
-    }
+    resolve_operator_connection_state(
+        (live_gateway.backend_state)(),
+        (live_gateway.live_status)()
+            .map(|event| event.level)
+            .or(gateway_level),
+    )
 }
 
 struct StatusPill {
@@ -71,19 +70,24 @@ struct StatusPill {
     label: &'static str,
 }
 
-fn status_pill(level: Option<LiveGatewayLevel>) -> StatusPill {
+fn status_pill(level: OperatorConnectionState) -> StatusPill {
     match level {
-        Some(LiveGatewayLevel::Healthy) => StatusPill {
+        OperatorConnectionState::Connected => StatusPill {
             class: "inline-flex items-center gap-3 rounded-full border border-emerald-300/20 bg-emerald-300/10 px-4 py-3 text-sm font-medium text-emerald-100 shadow-[0_12px_32px_rgba(2,6,23,0.28)] backdrop-blur-xl",
             dot_class: "inline-block shrink-0 text-[1rem] leading-none text-emerald-300 drop-shadow-[0_0_8px_rgba(110,231,183,0.95)]",
             label: "Connected",
         },
-        Some(LiveGatewayLevel::Degraded) => StatusPill {
+        OperatorConnectionState::Degraded => StatusPill {
             class: "inline-flex items-center gap-3 rounded-full border border-amber-400/20 bg-amber-400/10 px-4 py-3 text-sm font-medium text-amber-100 shadow-[0_12px_32px_rgba(2,6,23,0.28)] backdrop-blur-xl",
             dot_class: "inline-block shrink-0 text-[1rem] leading-none text-amber-300 drop-shadow-[0_0_8px_rgba(252,211,77,0.9)]",
             label: "Degraded",
         },
-        Some(LiveGatewayLevel::Connecting) | None => StatusPill {
+        OperatorConnectionState::Disconnected => StatusPill {
+            class: "inline-flex items-center gap-3 rounded-full border border-rose-300/20 bg-rose-300/10 px-4 py-3 text-sm font-medium text-rose-100 shadow-[0_12px_32px_rgba(2,6,23,0.28)] backdrop-blur-xl",
+            dot_class: "inline-block shrink-0 text-[1rem] leading-none text-rose-300 drop-shadow-[0_0_8px_rgba(253,164,175,0.9)]",
+            label: "Disconnected",
+        },
+        OperatorConnectionState::Connecting => StatusPill {
             class: "inline-flex items-center gap-3 rounded-full border border-white/12 bg-white/6 px-4 py-3 text-sm font-medium text-slate-100 shadow-[0_12px_32px_rgba(2,6,23,0.28)] backdrop-blur-xl",
             dot_class: "inline-block shrink-0 text-[1rem] leading-none text-amber-300 drop-shadow-[0_0_8px_rgba(252,211,77,0.9)]",
             label: "Connecting",
@@ -93,31 +97,18 @@ fn status_pill(level: Option<LiveGatewayLevel>) -> StatusPill {
 
 #[cfg(test)]
 mod tests {
-    use super::{LiveGatewayLevel, combine_gateway_levels, status_pill};
+    use super::{OperatorConnectionState, status_pill};
 
     #[test]
-    fn connecting_live_state_falls_back_to_healthy_snapshot() {
-        let resolved = combine_gateway_levels(
-            Some(LiveGatewayLevel::Healthy),
-            Some(LiveGatewayLevel::Connecting),
-        );
+    fn disconnected_pill_uses_disconnected_label() {
+        let pill = status_pill(OperatorConnectionState::Disconnected);
 
-        assert!(matches!(resolved, Some(LiveGatewayLevel::Healthy)));
-    }
-
-    #[test]
-    fn degraded_live_state_overrides_healthy_snapshot() {
-        let resolved = combine_gateway_levels(
-            Some(LiveGatewayLevel::Healthy),
-            Some(LiveGatewayLevel::Degraded),
-        );
-
-        assert!(matches!(resolved, Some(LiveGatewayLevel::Degraded)));
+        assert_eq!(pill.label, "Disconnected");
     }
 
     #[test]
     fn healthy_pill_uses_connected_label() {
-        let pill = status_pill(Some(LiveGatewayLevel::Healthy));
+        let pill = status_pill(OperatorConnectionState::Connected);
 
         assert_eq!(pill.label, "Connected");
     }

--- a/src/models/live_gateway.rs
+++ b/src/models/live_gateway.rs
@@ -8,6 +8,7 @@ pub enum LiveGatewayLevel {
     Healthy,
     Degraded,
     Connecting,
+    Disconnected,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -15,4 +16,75 @@ pub struct LiveGatewayEvent {
     pub level: LiveGatewayLevel,
     pub summary: String,
     pub detail: String,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum BackendConnectionState {
+    Connecting,
+    Connected,
+    Disconnected,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum OperatorConnectionState {
+    Connected,
+    Connecting,
+    Disconnected,
+    Degraded,
+}
+
+pub fn resolve_operator_connection_state(
+    backend_state: BackendConnectionState,
+    gateway_level: Option<LiveGatewayLevel>,
+) -> OperatorConnectionState {
+    match backend_state {
+        BackendConnectionState::Disconnected => OperatorConnectionState::Disconnected,
+        BackendConnectionState::Connecting => match gateway_level {
+            Some(LiveGatewayLevel::Healthy) => OperatorConnectionState::Connected,
+            Some(LiveGatewayLevel::Degraded) => OperatorConnectionState::Degraded,
+            Some(LiveGatewayLevel::Disconnected) => OperatorConnectionState::Disconnected,
+            Some(LiveGatewayLevel::Connecting) | None => OperatorConnectionState::Connecting,
+        },
+        BackendConnectionState::Connected => match gateway_level {
+            Some(LiveGatewayLevel::Healthy) => OperatorConnectionState::Connected,
+            Some(LiveGatewayLevel::Degraded) => OperatorConnectionState::Degraded,
+            Some(LiveGatewayLevel::Disconnected) => OperatorConnectionState::Disconnected,
+            Some(LiveGatewayLevel::Connecting) | None => OperatorConnectionState::Connecting,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        BackendConnectionState, LiveGatewayLevel, OperatorConnectionState,
+        resolve_operator_connection_state,
+    };
+
+    #[test]
+    fn disconnected_backend_overrides_gateway_health() {
+        let state = resolve_operator_connection_state(
+            BackendConnectionState::Disconnected,
+            Some(LiveGatewayLevel::Healthy),
+        );
+
+        assert_eq!(state, OperatorConnectionState::Disconnected);
+    }
+
+    #[test]
+    fn connected_backend_with_degraded_gateway_stays_degraded() {
+        let state = resolve_operator_connection_state(
+            BackendConnectionState::Connected,
+            Some(LiveGatewayLevel::Degraded),
+        );
+
+        assert_eq!(state, OperatorConnectionState::Degraded);
+    }
+
+    #[test]
+    fn connecting_backend_without_gateway_state_is_connecting() {
+        let state = resolve_operator_connection_state(BackendConnectionState::Connecting, None);
+
+        assert_eq!(state, OperatorConnectionState::Connecting);
+    }
 }

--- a/tests/e2e_mock_gateway.rs
+++ b/tests/e2e_mock_gateway.rs
@@ -3,32 +3,21 @@
 mod support;
 
 use serial_test::serial;
-use std::sync::{Mutex, MutexGuard};
 
-use support::{BrowserTestApp, degraded_app, healthy_app};
+use support::{with_degraded_app, with_healthy_app};
 
 const PAGE_OK: &str = "HTTP/1.1 200 OK";
 const PAGE_ERROR: &str = "Internal Server Error";
 const DASHBOARD_REQUIRED: &[&str] = &[PAGE_OK, "Mission Control", "Gateway status"];
 const AGENTS_REQUIRED: &[&str] = &[PAGE_OK, "Graph View", "Loading agents"];
 
-fn lock_app<'a>(app: &'a Mutex<BrowserTestApp>, label: &str) -> MutexGuard<'a, BrowserTestApp> {
-    match app.lock() {
-        Ok(guard) => guard,
-        Err(poisoned) => {
-            eprintln!("recovering poisoned {label} app state after an earlier test failure");
-            poisoned.into_inner()
-        }
-    }
-}
-
-fn expect_dashboard_shell(app: &mut BrowserTestApp) -> String {
+fn expect_dashboard_shell(app: &mut support::BrowserTestApp) -> String {
     let response = app.wait_for_page_response("/", DASHBOARD_REQUIRED, &[PAGE_ERROR]);
     assert!(response.contains("/assets/main-"));
     response
 }
 
-fn expect_agents_shell(app: &mut BrowserTestApp) -> String {
+fn expect_agents_shell(app: &mut support::BrowserTestApp) -> String {
     let response = app.wait_for_page_response("/agents", AGENTS_REQUIRED, &[PAGE_ERROR]);
     assert!(response.contains("/assets/main-"));
     response
@@ -37,78 +26,78 @@ fn expect_agents_shell(app: &mut BrowserTestApp) -> String {
 #[test]
 #[serial]
 fn healthy_gateway_event_stream_replays_latest_health_state() {
-    let mut app = lock_app(healthy_app(), "healthy");
+    with_healthy_app(|app| {
+        let event_stream = app.wait_for_gateway_event(
+            &[
+                "HTTP/1.1 200 OK",
+                "content-type: text/event-stream",
+                "\"level\":\"healthy\"",
+                "\"summary\":\"Gateway health update: healthy.\"",
+            ],
+            &[],
+        );
 
-    let event_stream = app.wait_for_gateway_event(
-        &[
-            "HTTP/1.1 200 OK",
-            "content-type: text/event-stream",
-            "\"level\":\"healthy\"",
-            "\"summary\":\"Gateway health update: healthy.\"",
-        ],
-        &[],
-    );
-
-    assert!(event_stream.contains("\"detail\":\"Live gateway event received.\""));
+        assert!(event_stream.contains("\"detail\":\"Live gateway event received.\""));
+    });
 }
 
 #[test]
 #[serial]
 fn healthy_gateway_dashboard_and_agents_render() {
-    let mut app = lock_app(healthy_app(), "healthy");
-
-    let _ = expect_dashboard_shell(&mut app);
-    let _ = expect_agents_shell(&mut app);
+    with_healthy_app(|app| {
+        let _ = expect_dashboard_shell(app);
+        let _ = expect_agents_shell(app);
+    });
 }
 
 #[test]
 #[serial]
 fn degraded_gateway_event_stream_replays_reconnecting_state() {
-    let mut app = lock_app(degraded_app(), "degraded");
+    with_degraded_app(|app| {
+        let event_stream = app.wait_for_gateway_event(
+            &[
+                "HTTP/1.1 200 OK",
+                "content-type: text/event-stream",
+                "\"level\":\"connecting\"",
+                "Gateway event stream reconnecting",
+            ],
+            &[],
+        );
 
-    let event_stream = app.wait_for_gateway_event(
-        &[
-            "HTTP/1.1 200 OK",
-            "content-type: text/event-stream",
-            "\"level\":\"connecting\"",
-            "Gateway event stream reconnecting",
-        ],
-        &[],
-    );
-
-    assert!(event_stream.contains("Could not open gateway websocket"));
+        assert!(event_stream.contains("Could not open gateway websocket"));
+    });
 }
 
 #[test]
 #[serial]
 fn degraded_gateway_dashboard_renders_error_state() {
-    let mut app = lock_app(degraded_app(), "degraded");
-
-    let _ = expect_dashboard_shell(&mut app);
+    with_degraded_app(|app| {
+        let _ = expect_dashboard_shell(app);
+    });
 }
 
 #[test]
 #[serial]
 fn agents_view_renders_loading_shell_without_errors() {
-    let mut app = lock_app(healthy_app(), "healthy");
-
-    let _ = expect_agents_shell(&mut app);
+    with_healthy_app(|app| {
+        let _ = expect_agents_shell(app);
+    });
 }
 
 #[test]
 #[serial]
 fn dashboard_route_remains_available_across_repeated_requests() {
-    let mut app = lock_app(healthy_app(), "healthy");
-
-    let _ = expect_dashboard_shell(&mut app);
-    let _ = expect_dashboard_shell(&mut app);
+    with_healthy_app(|app| {
+        let _ = expect_dashboard_shell(app);
+        let _ = expect_dashboard_shell(app);
+    });
 }
 
 #[test]
 #[serial]
 fn agents_route_remains_available_across_repeated_requests() {
-    let mut app = lock_app(healthy_app(), "healthy");
-
-    let _ = expect_agents_shell(&mut app);
-    let _ = expect_agents_shell(&mut app);
+    with_healthy_app(|app| {
+        let _ = expect_agents_shell(app);
+        let _ = expect_agents_shell(app);
+    });
 }

--- a/tests/support/app.rs
+++ b/tests/support/app.rs
@@ -13,8 +13,8 @@ use std::net::SocketAddr;
 
 pub struct BrowserTestApp {
     _fixture: TestFixture,
-    _gateway: Option<MockGateway>,
     process: RunningProcess,
+    _gateway: Option<MockGateway>,
     port: u16,
 }
 

--- a/tests/support/gateway.rs
+++ b/tests/support/gateway.rs
@@ -83,6 +83,7 @@ fn handle_gateway_client(stream: TcpStream, payload: &GatewayPayload) -> Result<
             Err(tungstenite::Error::ConnectionClosed) | Err(tungstenite::Error::AlreadyClosed) => {
                 return Ok(());
             }
+            Err(error) if is_client_disconnect(&error) => return Ok(()),
             Err(error) => return Err(format!("read gateway message: {error}")),
         };
 
@@ -107,6 +108,18 @@ fn handle_gateway_client(stream: TcpStream, payload: &GatewayPayload) -> Result<
             .send(Message::Text(response.to_string().into()))
             .map_err(|error| format!("send gateway response: {error}"))?;
     }
+}
+
+fn is_client_disconnect(error: &tungstenite::Error) -> bool {
+    matches!(error, tungstenite::Error::Io(io_error) if matches!(
+        io_error.kind(),
+        std::io::ErrorKind::ConnectionReset
+            | std::io::ErrorKind::ConnectionAborted
+            | std::io::ErrorKind::UnexpectedEof
+            | std::io::ErrorKind::BrokenPipe
+    )) || error
+        .to_string()
+        .contains("Connection reset without closing handshake")
 }
 
 fn connect_response(request: &Value, payload: &GatewayPayload) -> Value {

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -9,45 +9,65 @@ mod util;
 use std::sync::{Mutex, OnceLock};
 
 pub use app::BrowserTestApp;
+use process::cleanup_stale_dioxus_processes;
 use util::{COMMAND_TIMEOUT, ensure_tool, run_command_success};
 
 static TEST_ENVIRONMENT: OnceLock<()> = OnceLock::new();
-static HEALTHY_APP: OnceLock<Mutex<BrowserTestApp>> = OnceLock::new();
-static DEGRADED_APP: OnceLock<Mutex<BrowserTestApp>> = OnceLock::new();
+static CLEANUP: OnceLock<()> = OnceLock::new();
+static HEALTHY_APP: OnceLock<Mutex<Option<BrowserTestApp>>> = OnceLock::new();
+static DEGRADED_APP: OnceLock<Mutex<Option<BrowserTestApp>>> = OnceLock::new();
 
-pub fn healthy_app() -> &'static Mutex<BrowserTestApp> {
-    init_browser_test_app(
+pub fn with_healthy_app<T>(f: impl FnOnce(&mut BrowserTestApp) -> T) -> T {
+    with_browser_test_app(
         &HEALTHY_APP,
         BrowserTestApp::healthy,
         "start healthy browser test app",
+        f,
     )
 }
 
-pub fn degraded_app() -> &'static Mutex<BrowserTestApp> {
-    init_browser_test_app(
+pub fn with_degraded_app<T>(f: impl FnOnce(&mut BrowserTestApp) -> T) -> T {
+    with_browser_test_app(
         &DEGRADED_APP,
         BrowserTestApp::degraded,
         "start degraded browser test app",
+        f,
     )
 }
 
-fn init_browser_test_app(
-    slot: &'static OnceLock<Mutex<BrowserTestApp>>,
+fn with_browser_test_app<T>(
+    slot: &'static OnceLock<Mutex<Option<BrowserTestApp>>>,
     builder: fn() -> Result<BrowserTestApp, String>,
     context: &str,
-) -> &'static Mutex<BrowserTestApp> {
-    slot.get_or_init(|| {
+    f: impl FnOnce(&mut BrowserTestApp) -> T,
+) -> T {
+    let app = slot.get_or_init(|| {
         prepare_browser_test_environment();
-        Mutex::new(builder().unwrap_or_else(|error| {
+        register_browser_test_cleanup();
+        Mutex::new(Some(builder().unwrap_or_else(|error| {
             panic!("{context} failed: {error}");
-        }))
-    })
+        })))
+    });
+
+    let mut guard = match app.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => {
+            eprintln!("recovering poisoned browser test app state after an earlier test failure");
+            poisoned.into_inner()
+        }
+    };
+
+    let app = guard
+        .as_mut()
+        .unwrap_or_else(|| panic!("{context} was already cleaned up"));
+    f(app)
 }
 
 fn prepare_browser_test_environment() {
     TEST_ENVIRONMENT.get_or_init(|| {
         ensure_tool("dx");
         ensure_tool("npm");
+        cleanup_stale_dioxus_processes();
         run_command_success(
             std::process::Command::new("npm")
                 .arg("run")
@@ -56,4 +76,29 @@ fn prepare_browser_test_environment() {
             COMMAND_TIMEOUT,
         );
     });
+}
+
+fn register_browser_test_cleanup() {
+    CLEANUP.get_or_init(|| unsafe {
+        libc::atexit(cleanup_browser_test_apps);
+    });
+}
+
+extern "C" fn cleanup_browser_test_apps() {
+    cleanup_browser_test_slot(&HEALTHY_APP);
+    cleanup_browser_test_slot(&DEGRADED_APP);
+}
+
+fn cleanup_browser_test_slot(slot: &'static OnceLock<Mutex<Option<BrowserTestApp>>>) {
+    if let Some(app) = slot.get() {
+        match app.lock() {
+            Ok(mut guard) => {
+                *guard = None;
+            }
+            Err(poisoned) => {
+                let mut guard = poisoned.into_inner();
+                *guard = None;
+            }
+        }
+    }
 }

--- a/tests/support/process.rs
+++ b/tests/support/process.rs
@@ -1,15 +1,22 @@
 // SPDX-License-Identifier: Apache-2.0
 
+#[cfg(unix)]
+use libc::{SIGKILL, SIGTERM, kill, setpgid};
 use std::{
+    fs,
     io::{BufRead, BufReader, Read},
+    path::{Path, PathBuf},
     process::{Child, Command, Stdio},
     sync::{Arc, Mutex},
     thread,
 };
+#[cfg(unix)]
+use std::{os::unix::process::CommandExt, time::Duration};
 
 pub(crate) struct RunningProcess {
     child: Child,
     logs: Arc<Mutex<String>>,
+    pid_registry: ProcessRegistry,
 }
 
 impl RunningProcess {
@@ -17,7 +24,8 @@ impl RunningProcess {
         app_port: u16,
         config_path: &std::path::Path,
     ) -> Result<Self, String> {
-        let mut child = Command::new("dx")
+        let mut command = Command::new("dx");
+        command
             .arg("serve")
             .arg("--web")
             .arg("--fullstack")
@@ -29,14 +37,32 @@ impl RunningProcess {
             .arg("false")
             .env("OPENCLAW_CONFIG_PATH", config_path)
             .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
+            .stderr(Stdio::piped());
+
+        #[cfg(unix)]
+        unsafe {
+            command.pre_exec(|| {
+                if setpgid(0, 0) == 0 {
+                    Ok(())
+                } else {
+                    Err(std::io::Error::last_os_error())
+                }
+            });
+        }
+
+        let mut child = command
             .spawn()
             .map_err(|error| format!("Could not start dx serve: {error}"))?;
 
         let logs = Arc::new(Mutex::new(String::new()));
         pipe_child_output(&mut child, Arc::clone(&logs));
+        let pid_registry = ProcessRegistry::register(child.id());
 
-        Ok(Self { child, logs })
+        Ok(Self {
+            child,
+            logs,
+            pid_registry,
+        })
     }
 
     pub(crate) fn assert_still_running(&mut self) {
@@ -59,8 +85,48 @@ impl RunningProcess {
 
 impl Drop for RunningProcess {
     fn drop(&mut self) {
+        #[cfg(unix)]
+        terminate_process_group(self.child.id());
+
         let _ = self.child.kill();
-        let _ = self.child.wait();
+        wait_for_exit(&mut self.child);
+        self.pid_registry.unregister();
+    }
+}
+
+pub(crate) fn cleanup_stale_dioxus_processes() {
+    for pid in ProcessRegistry::tracked_pids() {
+        #[cfg(unix)]
+        terminate_process_group(pid);
+        ProcessRegistry::unregister_pid(pid);
+    }
+}
+
+#[cfg(unix)]
+fn terminate_process_group(child_id: u32) {
+    let pgid = child_id as i32;
+    let process_group = -pgid;
+
+    unsafe {
+        let _ = kill(process_group, SIGTERM);
+    }
+
+    thread::sleep(Duration::from_millis(200));
+
+    unsafe {
+        let _ = kill(process_group, SIGKILL);
+    }
+}
+
+fn wait_for_exit(child: &mut Child) {
+    let started = std::time::Instant::now();
+
+    while started.elapsed() < Duration::from_secs(2) {
+        match child.try_wait() {
+            Ok(Some(_)) => return,
+            Ok(None) => thread::sleep(Duration::from_millis(50)),
+            Err(_) => return,
+        }
     }
 }
 
@@ -90,4 +156,69 @@ fn read_pipe<T: Read>(mut pipe: T, logs: Arc<Mutex<String>>) {
             Err(_) => break,
         }
     }
+}
+
+struct ProcessRegistry {
+    pid: u32,
+    path: PathBuf,
+}
+
+impl ProcessRegistry {
+    fn register(pid: u32) -> Self {
+        let path = registry_path();
+        let mut pids = read_pid_registry(&path);
+        if !pids.contains(&pid) {
+            pids.push(pid);
+            write_pid_registry(&path, &pids);
+        }
+        Self { pid, path }
+    }
+
+    fn tracked_pids() -> Vec<u32> {
+        read_pid_registry(&registry_path())
+    }
+
+    fn unregister(&self) {
+        Self::unregister_pid_from_path(&self.path, self.pid);
+    }
+
+    fn unregister_pid(pid: u32) {
+        Self::unregister_pid_from_path(&registry_path(), pid);
+    }
+
+    fn unregister_pid_from_path(path: &Path, pid: u32) {
+        let mut pids = read_pid_registry(path);
+        pids.retain(|tracked| *tracked != pid);
+        write_pid_registry(path, &pids);
+    }
+}
+
+fn registry_path() -> PathBuf {
+    std::env::temp_dir().join("daneel-e2e-dx-pids.txt")
+}
+
+fn read_pid_registry(path: &Path) -> Vec<u32> {
+    fs::read_to_string(path)
+        .ok()
+        .map(|contents| {
+            contents
+                .lines()
+                .filter_map(|line| line.trim().parse::<u32>().ok())
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn write_pid_registry(path: &Path, pids: &[u32]) {
+    if pids.is_empty() {
+        let _ = fs::remove_file(path);
+        return;
+    }
+
+    let body = pids
+        .iter()
+        .map(u32::to_string)
+        .collect::<Vec<_>>()
+        .join("\n");
+    let _ = fs::write(path, format!("{body}\n"));
 }


### PR DESCRIPTION
Task: #38 [POC V1] T2.8 Add live backend connection and reconnection state management

Closes #38

## Summary
- add explicit live backend connection state handling for connected, connecting, disconnected, and degraded states
- freeze and visually subdue views while the backend event stream is disconnected
- harden the e2e harness so dx serve processes are cleaned up reliably and stale leaks are purged automatically

## Verification
- cargo fmt --all --check
- cargo check --features server
- cargo check --target wasm32-unknown-unknown
- cargo test
- cargo test --test e2e_mock_gateway -- --nocapture (repeated)