### PR TITLE
[T3.1] Create the adapter trait and OpenClaw adapter module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ npm-debug.log*
 # Generated Tailwind output
 /assets/main.css
 .ccp
+daneel.toml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -727,6 +727,7 @@ dependencies = [
 name = "daneel"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "dioxus",
  "dioxus-history",
  "dioxus-router",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+async-trait = "0.1"
 dioxus = { version = "0.7.3", features = ["router", "fullstack"] }
 dioxus-server = { version = "0.7.3", optional = true }
 serde = { version = "1", features = ["derive"] }

--- a/src/adapter/mod.rs
+++ b/src/adapter/mod.rs
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: Apache-2.0
+#![cfg_attr(not(test), allow(dead_code))]
+
+#[cfg(feature = "server")]
+use async_trait::async_trait;
+
+#[cfg(feature = "server")]
+use crate::models::{
+    gateway::GatewayStatusSnapshot,
+    graph::{AgentEdge, AgentNode},
+    runtime::ActiveSessionRecord,
+};
+
+#[cfg(feature = "server")]
+pub mod openclaw;
+
+#[cfg(feature = "server")]
+#[async_trait]
+pub trait GatewayAdapter: Clone + Send + Sync + 'static {
+    async fn gateway_status(&self) -> Result<GatewayStatusSnapshot, String>;
+
+    async fn list_agents(&self) -> Result<Vec<AgentNode>, String>;
+
+    async fn list_agent_bindings(&self) -> Result<Vec<AgentEdge>, String>;
+
+    async fn list_active_sessions(&self) -> Result<Vec<ActiveSessionRecord>, String>;
+
+    async fn list_agent_relationship_hints(&self) -> Result<Vec<AgentEdge>, String>;
+}
+
+#[cfg(all(test, feature = "server"))]
+mod tests {
+    use async_trait::async_trait;
+
+    use super::GatewayAdapter;
+    use crate::models::{
+        gateway::{GatewayLevel, GatewayStatusSnapshot},
+        graph::{AgentEdge, AgentEdgeKind, AgentNode, AgentStatus},
+        runtime::ActiveSessionRecord,
+    };
+
+    #[derive(Clone, Debug, Default)]
+    struct MockAdapter;
+
+    fn sample_agent_node() -> AgentNode {
+        AgentNode {
+            id: "main".to_string(),
+            name: "main".to_string(),
+            is_default: true,
+            heartbeat_enabled: true,
+            heartbeat_schedule: "every 5m".to_string(),
+            active_session_count: 1,
+            latest_activity_age_ms: Some(1_000),
+            status: AgentStatus::Active,
+        }
+    }
+
+    fn sample_gateway_binding() -> AgentEdge {
+        AgentEdge {
+            source_id: "main".to_string(),
+            target_id: "planner".to_string(),
+            kind: AgentEdgeKind::GatewayRouting,
+        }
+    }
+
+    fn sample_relationship_hint() -> AgentEdge {
+        AgentEdge {
+            source_id: "main".to_string(),
+            target_id: "planner".to_string(),
+            kind: AgentEdgeKind::MetadataHint,
+        }
+    }
+
+    fn sample_active_session() -> ActiveSessionRecord {
+        ActiveSessionRecord {
+            session_id: "session-1".to_string(),
+            agent_id: "main".to_string(),
+            task: Some("status".to_string()),
+            age_ms: Some(1_000),
+        }
+    }
+
+    #[async_trait]
+    impl GatewayAdapter for MockAdapter {
+        async fn gateway_status(&self) -> Result<GatewayStatusSnapshot, String> {
+            Ok(GatewayStatusSnapshot {
+                connected: true,
+                level: GatewayLevel::Healthy,
+                summary: "healthy".to_string(),
+                detail: "mock".to_string(),
+                gateway_url: "ws://127.0.0.1:18789/".to_string(),
+                uptime_ms: Some(1000),
+            })
+        }
+
+        async fn list_agents(&self) -> Result<Vec<AgentNode>, String> {
+            Ok(vec![sample_agent_node()])
+        }
+
+        async fn list_agent_bindings(&self) -> Result<Vec<AgentEdge>, String> {
+            Ok(vec![sample_gateway_binding()])
+        }
+
+        async fn list_active_sessions(&self) -> Result<Vec<ActiveSessionRecord>, String> {
+            Ok(vec![sample_active_session()])
+        }
+
+        async fn list_agent_relationship_hints(&self) -> Result<Vec<AgentEdge>, String> {
+            Ok(vec![sample_relationship_hint()])
+        }
+    }
+
+    fn assert_trait_usage_is_shared_model_only(
+        adapter: &impl GatewayAdapter,
+    ) -> impl std::future::Future<
+        Output = (
+            Result<GatewayStatusSnapshot, String>,
+            Result<Vec<AgentNode>, String>,
+            Result<Vec<AgentEdge>, String>,
+            Result<Vec<ActiveSessionRecord>, String>,
+            Result<Vec<AgentEdge>, String>,
+        ),
+    > + '_ {
+        async move {
+            (
+                adapter.gateway_status().await,
+                adapter.list_agents().await,
+                adapter.list_agent_bindings().await,
+                adapter.list_active_sessions().await,
+                adapter.list_agent_relationship_hints().await,
+            )
+        }
+    }
+
+    #[tokio::test]
+    async fn mock_adapter_can_satisfy_the_trait() {
+        let adapter = MockAdapter;
+        let (status, agents, bindings, sessions, hints) =
+            assert_trait_usage_is_shared_model_only(&adapter).await;
+
+        assert!(status.expect("status").connected);
+        assert_eq!(agents.expect("agents").len(), 1);
+        assert_eq!(bindings.expect("bindings").len(), 1);
+        assert_eq!(sessions.expect("sessions").len(), 1);
+        assert_eq!(hints.expect("hints").len(), 1);
+    }
+}

--- a/src/adapter/openclaw.rs
+++ b/src/adapter/openclaw.rs
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#[cfg(feature = "server")]
+use async_trait::async_trait;
+
+#[cfg(feature = "server")]
+use crate::{
+    adapter::GatewayAdapter,
+    models::{
+        gateway::GatewayStatusSnapshot,
+        graph::{AgentEdge, AgentNode},
+        runtime::ActiveSessionRecord,
+    },
+};
+
+#[cfg(feature = "server")]
+#[derive(Clone, Debug, Default)]
+pub struct OpenClawAdapter;
+
+#[cfg(feature = "server")]
+fn not_implemented<T>(method: &str) -> Result<T, String> {
+    Err(format!(
+        "OpenClawAdapter::{method}() is not implemented yet."
+    ))
+}
+
+#[cfg(feature = "server")]
+#[async_trait]
+impl GatewayAdapter for OpenClawAdapter {
+    async fn gateway_status(&self) -> Result<GatewayStatusSnapshot, String> {
+        not_implemented("gateway_status")
+    }
+
+    async fn list_agents(&self) -> Result<Vec<AgentNode>, String> {
+        not_implemented("list_agents")
+    }
+
+    async fn list_agent_bindings(&self) -> Result<Vec<AgentEdge>, String> {
+        not_implemented("list_agent_bindings")
+    }
+
+    async fn list_active_sessions(&self) -> Result<Vec<ActiveSessionRecord>, String> {
+        not_implemented("list_active_sessions")
+    }
+
+    async fn list_agent_relationship_hints(&self) -> Result<Vec<AgentEdge>, String> {
+        not_implemented("list_agent_relationship_hints")
+    }
+}

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -4,21 +4,19 @@
 use std::sync::OnceLock;
 
 #[cfg(feature = "server")]
+use crate::adapter::{GatewayAdapter, openclaw::OpenClawAdapter};
+#[cfg(feature = "server")]
 use crate::gateway::{LoadedGatewayConfig, load_gateway_config};
 
 #[cfg(feature = "server")]
-#[derive(Clone, Debug, Default)]
-pub struct OpenClawGatewayAdapter;
-
-#[cfg(feature = "server")]
 #[derive(Clone, Debug)]
-pub struct ServerAppState<A> {
+pub struct ServerAppState<A: GatewayAdapter> {
     gateway_config: LoadedGatewayConfig,
     adapter: A,
 }
 
 #[cfg(feature = "server")]
-impl<A> ServerAppState<A> {
+impl<A: GatewayAdapter> ServerAppState<A> {
     pub fn new(gateway_config: LoadedGatewayConfig, adapter: A) -> Self {
         Self {
             gateway_config,
@@ -44,7 +42,7 @@ impl<A> ServerAppState<A> {
 }
 
 #[cfg(feature = "server")]
-pub type DaneelAppState = ServerAppState<OpenClawGatewayAdapter>;
+pub type DaneelAppState = ServerAppState<OpenClawAdapter>;
 
 #[cfg(feature = "server")]
 static APP_STATE: OnceLock<Result<DaneelAppState, String>> = OnceLock::new();
@@ -59,12 +57,12 @@ pub fn warm_server_app_state() -> Result<&'static DaneelAppState, String> {
 #[cfg(feature = "server")]
 pub fn server_app_state() -> Result<&'static DaneelAppState, String> {
     cached_app_state(&APP_STATE, || {
-        DaneelAppState::from_loader(load_gateway_config, OpenClawGatewayAdapter)
+        DaneelAppState::from_loader(load_gateway_config, OpenClawAdapter)
     })
 }
 
 #[cfg(feature = "server")]
-fn cached_app_state<'a, A>(
+fn cached_app_state<'a, A: GatewayAdapter>(
     slot: &'a OnceLock<Result<ServerAppState<A>, String>>,
     init: impl FnOnce() -> Result<ServerAppState<A>, String>,
 ) -> Result<&'a ServerAppState<A>, String> {
@@ -88,12 +86,51 @@ mod tests {
         atomic::{AtomicUsize, Ordering},
     };
 
+    use async_trait::async_trait;
+
+    use crate::adapter::GatewayAdapter;
+    use crate::models::{
+        gateway::{GatewayLevel, GatewayStatusSnapshot},
+        graph::{AgentEdge, AgentNode},
+        runtime::ActiveSessionRecord,
+    };
+
     use super::ServerAppState;
     use crate::gateway::LoadedGatewayConfig;
 
     #[derive(Clone, Debug, PartialEq, Eq)]
     struct MockAdapter {
         name: &'static str,
+    }
+
+    #[async_trait]
+    impl GatewayAdapter for MockAdapter {
+        async fn gateway_status(&self) -> Result<GatewayStatusSnapshot, String> {
+            Ok(GatewayStatusSnapshot {
+                connected: true,
+                level: GatewayLevel::Healthy,
+                summary: "healthy".to_string(),
+                detail: self.name.to_string(),
+                gateway_url: "ws://127.0.0.1:18789/".to_string(),
+                uptime_ms: Some(1),
+            })
+        }
+
+        async fn list_agents(&self) -> Result<Vec<AgentNode>, String> {
+            Ok(Vec::new())
+        }
+
+        async fn list_agent_bindings(&self) -> Result<Vec<AgentEdge>, String> {
+            Ok(Vec::new())
+        }
+
+        async fn list_active_sessions(&self) -> Result<Vec<ActiveSessionRecord>, String> {
+            Ok(Vec::new())
+        }
+
+        async fn list_agent_relationship_hints(&self) -> Result<Vec<AgentEdge>, String> {
+            Ok(Vec::new())
+        }
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
+mod adapter;
 mod app_state;
 mod components;
 mod gateway;

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -4,3 +4,4 @@ pub mod agents;
 pub mod gateway;
 pub mod graph;
 pub mod live_gateway;
+pub mod runtime;

--- a/src/models/runtime.rs
+++ b/src/models/runtime.rs
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// This contract is introduced ahead of its first server-function consumer so the adapter
+// boundary can stay neutral in T3.1.
+#![allow(dead_code)]
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct ActiveSessionRecord {
+    pub session_id: String,
+    pub agent_id: String,
+    pub task: Option<String>,
+    pub age_ms: Option<u64>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ActiveSessionRecord;
+
+    #[test]
+    fn active_session_record_json_round_trip() {
+        let record = ActiveSessionRecord {
+            session_id: "session-1".to_string(),
+            agent_id: "planner".to_string(),
+            task: Some("plan".to_string()),
+            age_ms: Some(500),
+        };
+
+        let json = serde_json::to_string(&record).expect("serialize");
+        let deserialized: ActiveSessionRecord = serde_json::from_str(&json).expect("deserialize");
+
+        assert_eq!(record, deserialized);
+    }
+}


### PR DESCRIPTION
Task: #14 [POC V1] T3.1 Create the adapter trait and OpenClaw adapter module

Closes #14

## Summary
- add the server-side GatewayAdapter contract for the POC slice
- add the initial OpenClawAdapter stub and wire app state to store it
- add neutral runtime session models so the adapter boundary stays free of OpenClaw-specific protocol types

## Verification
- cargo fmt --all
- cargo check --features server
- cargo test