### PR TITLE
[T3.7] Implement list_agent_relationship_hints()

### DIFF
--- a/docs/milestones/proof-of-concept-1/poc_v1_task_breakdown.md
+++ b/docs/milestones/proof-of-concept-1/poc_v1_task_breakdown.md
@@ -646,10 +646,14 @@ Allowed sources:
 Tests:
 
 - unit test: planner `Works With` content maps to collaboration edges
+- unit test: `Works With` content with multiple entries maps to deterministic, deduplicated relationship edges
 - unit test: health-coach config delegation hint maps to a relationship edge
+- unit test: unknown referenced agent names are ignored safely and do not create dangling hints
 - unit test: missing local metadata returns an empty set without error
-- unit test: malformed markdown or malformed config does not fail the full graph load
+- unit test: malformed markdown or malformed config for one agent does not fail the full hint load for other agents
 - unit test: metadata parsing can be disabled by config
+- unit test: mixed markdown and config hints merge without duplicate edges
+- integration test: `OpenClawAdapter::list_agent_relationship_hints()` reads temp local agent metadata end to end and returns shared-model edges only
 
 ---
 

--- a/src/adapter/openclaw/hints.rs
+++ b/src/adapter/openclaw/hints.rs
@@ -1,0 +1,337 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    env, fs,
+    path::{Path, PathBuf},
+};
+
+use serde::Deserialize;
+
+use crate::models::graph::{AgentEdge, AgentEdgeKind};
+
+#[derive(Debug, Deserialize)]
+struct OpenClawHintsConfig {
+    #[serde(default)]
+    agents: AgentsConfig,
+    #[serde(default)]
+    daneel: DaneelHintsConfig,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct DaneelHintsConfig {
+    #[serde(default)]
+    relationship_hints: RelationshipHintsConfig,
+}
+
+#[derive(Debug, Deserialize)]
+struct RelationshipHintsConfig {
+    #[serde(default = "default_relationship_hints_enabled")]
+    enabled: bool,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct AgentsConfig {
+    #[serde(default)]
+    list: Vec<AgentConfigEntry>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct AgentConfigEntry {
+    id: String,
+    #[serde(default)]
+    name: String,
+    #[serde(default, rename = "agentDir")]
+    agent_dir: Option<PathBuf>,
+    #[serde(default)]
+    subagents: SubagentsConfig,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct SubagentsConfig {
+    #[serde(default, rename = "allowAgents")]
+    allow_agents: Vec<String>,
+}
+
+fn default_relationship_hints_enabled() -> bool {
+    true
+}
+
+impl Default for RelationshipHintsConfig {
+    fn default() -> Self {
+        Self {
+            enabled: default_relationship_hints_enabled(),
+        }
+    }
+}
+
+pub(super) fn load_agent_relationship_hints() -> Result<Vec<AgentEdge>, String> {
+    let config_path = openclaw_config_path()?;
+    load_agent_relationship_hints_from_path(&config_path)
+}
+
+pub(super) fn load_agent_relationship_hints_from_path(
+    config_path: &Path,
+) -> Result<Vec<AgentEdge>, String> {
+    let raw = fs::read_to_string(config_path)
+        .map_err(|error| format!("Could not read {}: {error}", config_path.display()))?;
+    let parsed: OpenClawHintsConfig = serde_json::from_str(&raw)
+        .map_err(|error| format!("Could not parse {}: {error}", config_path.display()))?;
+
+    if !parsed.daneel.relationship_hints.enabled {
+        return Ok(Vec::new());
+    }
+
+    let agent_root = config_path
+        .parent()
+        .map(|parent| parent.join("agents"))
+        .unwrap_or_else(|| PathBuf::from(".").join("agents"));
+    let alias_map = build_alias_map(&parsed.agents.list);
+    let known_ids: BTreeSet<_> = parsed
+        .agents
+        .list
+        .iter()
+        .map(|agent| agent.id.clone())
+        .collect();
+    let mut edge_keys = BTreeSet::new();
+
+    for agent in &parsed.agents.list {
+        collect_config_hint_edges(agent, &known_ids, &mut edge_keys);
+
+        let agent_dir = agent
+            .agent_dir
+            .clone()
+            .unwrap_or_else(|| agent_root.join(&agent.id).join("agent"));
+
+        collect_markdown_hint_edges(agent, &agent_dir, &alias_map, &mut edge_keys);
+        collect_agent_json_hint_edges(agent, &agent_dir, &alias_map, &mut edge_keys);
+    }
+
+    Ok(edge_keys
+        .into_iter()
+        .map(|(source_id, target_id)| metadata_edge(&source_id, &target_id))
+        .collect())
+}
+
+fn openclaw_config_path() -> Result<PathBuf, String> {
+    if let Ok(path) = env::var("OPENCLAW_CONFIG_PATH") {
+        return Ok(PathBuf::from(path));
+    }
+
+    let home = env::var("HOME").map_err(|_| "HOME is not set.".to_string())?;
+    Ok(PathBuf::from(home).join(".openclaw").join("openclaw.json"))
+}
+
+fn build_alias_map(agents: &[AgentConfigEntry]) -> BTreeMap<String, String> {
+    let mut aliases = BTreeMap::new();
+
+    for agent in agents {
+        aliases.insert(normalize_agent_key(&agent.id), agent.id.clone());
+        if !agent.name.trim().is_empty() {
+            aliases.insert(normalize_agent_key(&agent.name), agent.id.clone());
+        }
+    }
+
+    aliases
+}
+
+fn collect_config_hint_edges(
+    agent: &AgentConfigEntry,
+    known_ids: &BTreeSet<String>,
+    edge_keys: &mut BTreeSet<(String, String)>,
+) {
+    for target_id in &agent.subagents.allow_agents {
+        if known_ids.contains(target_id) && target_id != &agent.id {
+            edge_keys.insert((agent.id.clone(), target_id.clone()));
+        }
+    }
+}
+
+fn collect_markdown_hint_edges(
+    agent: &AgentConfigEntry,
+    agent_dir: &Path,
+    alias_map: &BTreeMap<String, String>,
+    edge_keys: &mut BTreeSet<(String, String)>,
+) {
+    let agents_md_path = agent_dir.join("AGENTS.md");
+    let Ok(markdown) = fs::read_to_string(&agents_md_path) else {
+        return;
+    };
+
+    for target_id in parse_works_with_targets(&markdown, alias_map) {
+        if target_id != agent.id {
+            edge_keys.insert((agent.id.clone(), target_id));
+        }
+    }
+}
+
+fn collect_agent_json_hint_edges(
+    agent: &AgentConfigEntry,
+    agent_dir: &Path,
+    alias_map: &BTreeMap<String, String>,
+    edge_keys: &mut BTreeSet<(String, String)>,
+) {
+    let agent_json_path = agent_dir.join("agent.json");
+    let Ok(raw) = fs::read_to_string(&agent_json_path) else {
+        return;
+    };
+    let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&raw) else {
+        return;
+    };
+
+    for target_id in extract_delegate_targets(&parsed, alias_map) {
+        if target_id != agent.id {
+            edge_keys.insert((agent.id.clone(), target_id));
+        }
+    }
+}
+
+fn parse_works_with_targets(
+    markdown: &str,
+    alias_map: &BTreeMap<String, String>,
+) -> BTreeSet<String> {
+    let mut in_works_with = false;
+    let mut targets = BTreeSet::new();
+
+    for line in markdown.lines() {
+        let trimmed = line.trim();
+
+        if trimmed.starts_with('#') {
+            let heading = trimmed.trim_start_matches('#').trim();
+            let normalized = normalize_agent_key(heading);
+            if normalized == "works-with" {
+                in_works_with = true;
+                continue;
+            }
+
+            if in_works_with {
+                break;
+            }
+        }
+
+        if !in_works_with || !(trimmed.starts_with("- ") || trimmed.starts_with("* ")) {
+            continue;
+        }
+
+        if let Some(target) = extract_markdown_target(trimmed, alias_map) {
+            targets.insert(target);
+        }
+    }
+
+    targets
+}
+
+fn extract_markdown_target(
+    bullet_line: &str,
+    alias_map: &BTreeMap<String, String>,
+) -> Option<String> {
+    let content = bullet_line
+        .trim_start_matches("- ")
+        .trim_start_matches("* ")
+        .trim();
+
+    if let Some(rest) = content.strip_prefix("**") {
+        let end = rest.find("**")?;
+        let candidate = &rest[..end];
+        return resolve_agent_reference(candidate, alias_map);
+    }
+
+    let candidate = content.split(':').next().unwrap_or(content);
+    resolve_agent_reference(candidate, alias_map)
+}
+
+fn extract_delegate_targets(
+    value: &serde_json::Value,
+    alias_map: &BTreeMap<String, String>,
+) -> BTreeSet<String> {
+    let mut targets = BTreeSet::new();
+    collect_delegate_targets(value, alias_map, &mut targets);
+    targets
+}
+
+fn collect_delegate_targets(
+    value: &serde_json::Value,
+    alias_map: &BTreeMap<String, String>,
+    targets: &mut BTreeSet<String>,
+) {
+    match value {
+        serde_json::Value::String(text) => {
+            for candidate in delegation_candidates(text) {
+                if let Some(target) = resolve_agent_reference(&candidate, alias_map) {
+                    targets.insert(target);
+                }
+            }
+        }
+        serde_json::Value::Array(values) => {
+            for value in values {
+                collect_delegate_targets(value, alias_map, targets);
+            }
+        }
+        serde_json::Value::Object(map) => {
+            for value in map.values() {
+                collect_delegate_targets(value, alias_map, targets);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn delegation_candidates(text: &str) -> Vec<String> {
+    let lower = text.to_lowercase();
+    let patterns = ["delegate to the ", "delegate to "];
+    let mut candidates = Vec::new();
+
+    for pattern in patterns {
+        let mut search_start = 0;
+        while let Some(index) = lower[search_start..].find(pattern) {
+            let start = search_start + index + pattern.len();
+            let remaining = &lower[start..];
+            if let Some(end) = remaining.find(" agent") {
+                let candidate = remaining[..end].trim();
+                if !candidate.is_empty() {
+                    candidates.push(candidate.to_string());
+                }
+            }
+            search_start = start;
+        }
+    }
+
+    candidates
+}
+
+fn resolve_agent_reference(
+    candidate: &str,
+    alias_map: &BTreeMap<String, String>,
+) -> Option<String> {
+    alias_map.get(&normalize_agent_key(candidate)).cloned()
+}
+
+fn normalize_agent_key(raw: &str) -> String {
+    let mut normalized = raw.to_lowercase();
+    normalized = normalized.replace("**", "");
+    normalized = normalized
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || ch == ' ' || ch == '-' || ch == '_' {
+                ch
+            } else {
+                ' '
+            }
+        })
+        .collect();
+
+    let trimmed = normalized.trim().trim_end_matches(" agent").trim();
+    trimmed
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join("-")
+        .replace('_', "-")
+}
+
+fn metadata_edge(source_id: &str, target_id: &str) -> AgentEdge {
+    AgentEdge {
+        source_id: source_id.to_string(),
+        target_id: target_id.to_string(),
+        kind: AgentEdgeKind::MetadataHint,
+    }
+}

--- a/src/adapter/openclaw/mod.rs
+++ b/src/adapter/openclaw/mod.rs
@@ -16,6 +16,8 @@ use crate::{
 #[cfg(feature = "server")]
 mod fetch;
 #[cfg(feature = "server")]
+mod hints;
+#[cfg(feature = "server")]
 mod mapping;
 #[cfg(feature = "server")]
 mod snapshot;
@@ -25,6 +27,8 @@ mod tests;
 
 #[cfg(feature = "server")]
 use fetch::fetch_connect_payload;
+#[cfg(feature = "server")]
+use hints::load_agent_relationship_hints;
 #[cfg(feature = "server")]
 use mapping::{map_agent_node, normalize_binding_edges};
 #[cfg(feature = "server")]
@@ -68,6 +72,6 @@ impl GatewayAdapter for OpenClawAdapter {
     }
 
     async fn list_agent_relationship_hints(&self) -> Result<Vec<AgentEdge>, String> {
-        not_implemented("list_agent_relationship_hints")
+        load_agent_relationship_hints()
     }
 }

--- a/src/adapter/openclaw/tests.rs
+++ b/src/adapter/openclaw/tests.rs
@@ -23,6 +23,7 @@ use crate::{
 
 use super::{
     OpenClawAdapter,
+    hints::load_agent_relationship_hints_from_path,
     mapping::{
         map_active_session_record, map_agent_node, map_binding_edge, normalize_active_sessions,
         normalize_binding_edges,
@@ -142,19 +143,52 @@ fn write_openclaw_config(
     tempdir: &std::path::Path,
     port: u16,
 ) -> Result<std::path::PathBuf, String> {
-    let config_path = tempdir.join("openclaw.json");
-    fs::write(
-        &config_path,
-        serde_json::to_vec_pretty(&json!({
+    write_custom_openclaw_config(
+        tempdir,
+        json!({
             "gateway": {
                 "port": port,
                 "auth": { "token": "test-token" }
             }
-        }))
-        .expect("serialize config"),
+        }),
+    )
+}
+
+fn write_custom_openclaw_config(
+    tempdir: &std::path::Path,
+    config: serde_json::Value,
+) -> Result<std::path::PathBuf, String> {
+    let config_path = tempdir.join("openclaw.json");
+    fs::write(
+        &config_path,
+        serde_json::to_vec_pretty(&config).expect("serialize config"),
     )
     .map_err(|error| format!("write config: {error}"))?;
     Ok(config_path)
+}
+
+fn write_agent_file(
+    tempdir: &std::path::Path,
+    agent_id: &str,
+    filename: &str,
+    contents: &str,
+) -> Result<(), String> {
+    let agent_dir = tempdir.join("agents").join(agent_id).join("agent");
+    fs::create_dir_all(&agent_dir).map_err(|error| format!("create agent dir: {error}"))?;
+    fs::write(agent_dir.join(filename), contents)
+        .map_err(|error| format!("write agent file: {error}"))
+}
+
+fn relationship_config(agents: serde_json::Value) -> serde_json::Value {
+    json!({
+        "gateway": {
+            "port": 18789,
+            "auth": { "token": "test-token" }
+        },
+        "agents": {
+            "list": agents
+        }
+    })
 }
 
 fn gateway_snapshot_payload(
@@ -581,4 +615,319 @@ async fn list_active_sessions_falls_back_to_agent_recent_entries() {
     assert_eq!(sessions[2].session_id, "session-3");
     assert_eq!(sessions[2].agent_id, "calendar");
     assert_eq!(sessions[2].task.as_deref(), Some("check inbox"));
+}
+
+#[test]
+fn planner_works_with_content_maps_to_collaboration_edges() {
+    let tempdir = tempdir().expect("create tempdir");
+    let config_path = write_custom_openclaw_config(
+        tempdir.path(),
+        relationship_config(json!([
+            { "id": "planner", "name": "Planner" },
+            { "id": "coder", "name": "Coder" },
+            { "id": "health-coach", "name": "Health Coach" },
+            { "id": "email", "name": "Email" },
+            { "id": "calendar", "name": "Calendar" }
+        ])),
+    )
+    .expect("write relationship config");
+    write_agent_file(
+        tempdir.path(),
+        "planner",
+        "AGENTS.md",
+        r#"
+### Works With
+- **Coder Agent**: For implementation details
+- **Health Coach**: For health workflows
+- **Email Agent**: For communication workflow planning
+- **Calendar Agent**: For scheduling and timeline integration
+"#,
+    )
+    .expect("write planner AGENTS");
+
+    let edges = load_agent_relationship_hints_from_path(&config_path)
+        .expect("load relationship hints from markdown");
+
+    assert_eq!(edges.len(), 4);
+    assert_eq!(edges[0].source_id, "planner");
+    assert_eq!(edges[0].target_id, "calendar");
+    assert_eq!(edges[3].target_id, "health-coach");
+    assert!(
+        edges
+            .iter()
+            .all(|edge| edge.kind == AgentEdgeKind::MetadataHint)
+    );
+}
+
+#[test]
+fn works_with_entries_are_deduplicated_and_deterministic() {
+    let tempdir = tempdir().expect("create tempdir");
+    let config_path = write_custom_openclaw_config(
+        tempdir.path(),
+        relationship_config(json!([
+            { "id": "planner", "name": "Planner" },
+            { "id": "coder", "name": "Coder" },
+            { "id": "calendar", "name": "Calendar" }
+        ])),
+    )
+    .expect("write relationship config");
+    write_agent_file(
+        tempdir.path(),
+        "planner",
+        "AGENTS.md",
+        r#"
+### Works With
+- **Coder Agent**: For implementation details
+- **Calendar Agent**: For scheduling
+- **Coder Agent**: Duplicate mention
+"#,
+    )
+    .expect("write planner AGENTS");
+
+    let edges = load_agent_relationship_hints_from_path(&config_path)
+        .expect("load deduplicated relationship hints");
+
+    assert_eq!(edges.len(), 2);
+    assert_eq!(edges[0].target_id, "calendar");
+    assert_eq!(edges[1].target_id, "coder");
+}
+
+#[test]
+fn health_coach_config_delegation_hint_maps_to_relationship_edge() {
+    let tempdir = tempdir().expect("create tempdir");
+    let config_path = write_custom_openclaw_config(
+        tempdir.path(),
+        relationship_config(json!([
+            { "id": "health-coach", "name": "Health Coach" },
+            { "id": "coder", "name": "Coder" }
+        ])),
+    )
+    .expect("write relationship config");
+    write_agent_file(
+        tempdir.path(),
+        "health-coach",
+        "agent.json",
+        r#"{
+  "constraints": {
+    "noSkillOrScriptModification": "If a task requires code or skill changes, delegate to the coder agent and never attempt to make the changes directly."
+  }
+}"#,
+    )
+    .expect("write health-coach agent.json");
+
+    let edges = load_agent_relationship_hints_from_path(&config_path)
+        .expect("load relationship hints from config");
+
+    assert_eq!(edges.len(), 1);
+    assert_eq!(edges[0].source_id, "health-coach");
+    assert_eq!(edges[0].target_id, "coder");
+    assert_eq!(edges[0].kind, AgentEdgeKind::MetadataHint);
+}
+
+#[test]
+fn unknown_referenced_agent_names_are_ignored_safely() {
+    let tempdir = tempdir().expect("create tempdir");
+    let config_path = write_custom_openclaw_config(
+        tempdir.path(),
+        relationship_config(json!([
+            { "id": "planner", "name": "Planner" },
+            { "id": "coder", "name": "Coder" }
+        ])),
+    )
+    .expect("write relationship config");
+    write_agent_file(
+        tempdir.path(),
+        "planner",
+        "AGENTS.md",
+        r#"
+### Works With
+- **Ghost Agent**: This should be ignored
+- **Coder Agent**: For implementation details
+"#,
+    )
+    .expect("write planner AGENTS");
+
+    let edges = load_agent_relationship_hints_from_path(&config_path)
+        .expect("load relationship hints safely");
+
+    assert_eq!(edges.len(), 1);
+    assert_eq!(edges[0].target_id, "coder");
+}
+
+#[test]
+fn missing_local_metadata_returns_empty_set_without_error() {
+    let tempdir = tempdir().expect("create tempdir");
+    let config_path = write_custom_openclaw_config(
+        tempdir.path(),
+        relationship_config(json!([
+            { "id": "planner", "name": "Planner" },
+            { "id": "coder", "name": "Coder" }
+        ])),
+    )
+    .expect("write relationship config");
+
+    let edges = load_agent_relationship_hints_from_path(&config_path)
+        .expect("empty metadata should not error");
+
+    assert!(edges.is_empty());
+}
+
+#[test]
+fn malformed_agent_metadata_does_not_fail_full_hint_load() {
+    let tempdir = tempdir().expect("create tempdir");
+    let config_path = write_custom_openclaw_config(
+        tempdir.path(),
+        relationship_config(json!([
+            { "id": "planner", "name": "Planner" },
+            { "id": "health-coach", "name": "Health Coach" },
+            { "id": "coder", "name": "Coder" }
+        ])),
+    )
+    .expect("write relationship config");
+    write_agent_file(
+        tempdir.path(),
+        "planner",
+        "AGENTS.md",
+        r#"
+### Works With
+- **Coder Agent**: For implementation details
+"#,
+    )
+    .expect("write planner AGENTS");
+    write_agent_file(
+        tempdir.path(),
+        "health-coach",
+        "agent.json",
+        "{ invalid json",
+    )
+    .expect("write invalid health-coach agent.json");
+
+    let edges = load_agent_relationship_hints_from_path(&config_path)
+        .expect("malformed metadata should be isolated");
+
+    assert_eq!(edges.len(), 1);
+    assert_eq!(edges[0].source_id, "planner");
+    assert_eq!(edges[0].target_id, "coder");
+}
+
+#[test]
+fn metadata_parsing_can_be_disabled_by_config() {
+    let tempdir = tempdir().expect("create tempdir");
+    let config_path = write_custom_openclaw_config(
+        tempdir.path(),
+        json!({
+            "gateway": {
+                "port": 18789,
+                "auth": { "token": "test-token" }
+            },
+            "daneel": {
+                "relationship_hints": {
+                    "enabled": false
+                }
+            },
+            "agents": {
+                "list": [
+                    { "id": "planner", "name": "Planner" },
+                    { "id": "coder", "name": "Coder" }
+                ]
+            }
+        }),
+    )
+    .expect("write disabled relationship config");
+    write_agent_file(
+        tempdir.path(),
+        "planner",
+        "AGENTS.md",
+        r#"
+### Works With
+- **Coder Agent**: For implementation details
+"#,
+    )
+    .expect("write planner AGENTS");
+
+    let edges = load_agent_relationship_hints_from_path(&config_path)
+        .expect("disabled metadata parsing should not error");
+
+    assert!(edges.is_empty());
+}
+
+#[test]
+fn mixed_markdown_and_config_hints_merge_without_duplicates() {
+    let tempdir = tempdir().expect("create tempdir");
+    let config_path = write_custom_openclaw_config(
+        tempdir.path(),
+        relationship_config(json!([
+            {
+                "id": "planner",
+                "name": "Planner",
+                "subagents": {
+                    "allowAgents": ["coder", "calendar"]
+                }
+            },
+            { "id": "coder", "name": "Coder" },
+            { "id": "calendar", "name": "Calendar" }
+        ])),
+    )
+    .expect("write relationship config");
+    write_agent_file(
+        tempdir.path(),
+        "planner",
+        "AGENTS.md",
+        r#"
+### Works With
+- **Coder Agent**: For implementation details
+"#,
+    )
+    .expect("write planner AGENTS");
+
+    let edges = load_agent_relationship_hints_from_path(&config_path)
+        .expect("merge markdown and config hints");
+
+    assert_eq!(edges.len(), 2);
+    assert_eq!(edges[0].target_id, "calendar");
+    assert_eq!(edges[1].target_id, "coder");
+}
+
+#[tokio::test]
+#[serial]
+async fn list_agent_relationship_hints_reads_local_metadata_end_to_end() {
+    let tempdir = tempdir().expect("create tempdir");
+    let config_path = write_custom_openclaw_config(
+        tempdir.path(),
+        relationship_config(json!([
+            { "id": "planner", "name": "Planner" },
+            { "id": "coder", "name": "Coder" },
+            { "id": "calendar", "name": "Calendar" }
+        ])),
+    )
+    .expect("write relationship config");
+    write_agent_file(
+        tempdir.path(),
+        "planner",
+        "AGENTS.md",
+        r#"
+### Works With
+- **Coder Agent**: For implementation details
+- **Calendar Agent**: For scheduling
+"#,
+    )
+    .expect("write planner AGENTS");
+    let _guard = EnvVarGuard::set(
+        "OPENCLAW_CONFIG_PATH",
+        config_path.to_str().expect("config path as utf-8"),
+    );
+
+    let edges = OpenClawAdapter
+        .list_agent_relationship_hints()
+        .await
+        .expect("list relationship hints through adapter");
+
+    assert_eq!(edges.len(), 2);
+    assert_eq!(edges[0].source_id, "planner");
+    assert_eq!(edges[0].target_id, "calendar");
+    assert!(
+        edges
+            .iter()
+            .all(|edge| edge.kind == AgentEdgeKind::MetadataHint)
+    );
 }


### PR DESCRIPTION
Task: #20 [POC V1] T3.7 Implement `list_agent_relationship_hints()`

Closes #20

## Summary
- implement OpenClaw adapter relationship hint loading from local agent metadata
- add stronger T3.7 task coverage and adapter-path integration tests
- keep hint parsing isolated from shared UI models

## Verification
- cargo fmt --all --check
- cargo check --features server
- cargo test
- npm run build:css
- dx serve --web --fullstack --addr 127.0.0.1 --port 4127 --open false
- curl -I http://127.0.0.1:4127
- curl -I http://127.0.0.1:4127/wasm/daneel.js