### PR TITLE
[T7.2] Add end-to-end POC smoke test

### DIFF
--- a/scripts/verify-route.mjs
+++ b/scripts/verify-route.mjs
@@ -11,7 +11,9 @@ function parseArgs(argv) {
     screenshot: "",
     dom: "",
     waitTexts: [],
+    waitSelectors: [],
     forbidTexts: [],
+    forbidSelectors: [],
     timeoutMs: 40_000,
     viewport: "1600,1400",
     chromePath: "/usr/bin/google-chrome",
@@ -34,8 +36,14 @@ function parseArgs(argv) {
     } else if (arg === "--wait-text") {
       options.waitTexts.push(next);
       i += 1;
+    } else if (arg === "--wait-selector") {
+      options.waitSelectors.push(next);
+      i += 1;
     } else if (arg === "--forbid-text") {
       options.forbidTexts.push(next);
+      i += 1;
+    } else if (arg === "--forbid-selector") {
+      options.forbidSelectors.push(next);
       i += 1;
     } else if (arg === "--timeout-ms") {
       options.timeoutMs = Number.parseInt(next, 10);
@@ -53,8 +61,8 @@ function parseArgs(argv) {
 
   if (!options.url) throw new Error("Missing required --url");
   if (!options.screenshot) throw new Error("Missing required --screenshot");
-  if (options.waitTexts.length === 0) {
-    throw new Error("Provide at least one --wait-text");
+  if (options.waitTexts.length === 0 && options.waitSelectors.length === 0) {
+    throw new Error("Provide at least one --wait-text or --wait-selector");
   }
 
   return options;
@@ -73,7 +81,7 @@ function parseViewport(value) {
 
 async function waitForHydration(page, options) {
   await page.waitForFunction(
-    ({ waitTexts, forbidTexts }) => {
+    ({ waitTexts, waitSelectors, forbidTexts, forbidSelectors }) => {
       const body = document.body;
       if (!body) return false;
 
@@ -86,8 +94,14 @@ async function waitForHydration(page, options) {
       const hasAllRequired = waitTexts.every((entry) =>
         text.includes(entry.toLowerCase())
       );
+      const hasAllRequiredSelectors = waitSelectors.every((selector) =>
+        document.querySelector(selector)
+      );
       const hasForbidden = forbidTexts.some((entry) =>
         text.includes(entry.toLowerCase())
+      );
+      const hasForbiddenSelectors = forbidSelectors.some((selector) =>
+        document.querySelector(selector)
       );
 
       return (
@@ -95,10 +109,17 @@ async function waitForHydration(page, options) {
         stylesheetReady &&
         bodyStyled &&
         hasAllRequired &&
-        !hasForbidden
+        hasAllRequiredSelectors &&
+        !hasForbidden &&
+        !hasForbiddenSelectors
       );
     },
-    { waitTexts: options.waitTexts, forbidTexts: options.forbidTexts },
+    {
+      waitTexts: options.waitTexts,
+      waitSelectors: options.waitSelectors,
+      forbidTexts: options.forbidTexts,
+      forbidSelectors: options.forbidSelectors,
+    },
     { timeout: options.timeoutMs }
   );
 }
@@ -113,20 +134,34 @@ async function main() {
 
   try {
     const page = await browser.newPage({ viewport: parseViewport(options.viewport) });
-    await page.goto(options.url, { waitUntil: "domcontentloaded" });
-    await waitForHydration(page, options);
+    try {
+      await page.goto(options.url, { waitUntil: "domcontentloaded" });
+      await waitForHydration(page, options);
 
-    const html = await page.content();
-    await page.screenshot({
-      path: options.screenshot,
-      fullPage: options.fullPage,
-    });
+      const html = await page.content();
+      await page.screenshot({
+        path: options.screenshot,
+        fullPage: options.fullPage,
+      });
 
-    if (options.dom) {
-      await fs.writeFile(options.dom, html, "utf8");
+      if (options.dom) {
+        await fs.writeFile(options.dom, html, "utf8");
+      }
+
+      process.stdout.write(`Verified and captured ${options.url}\n`);
+    } catch (error) {
+      const html = await page.content();
+      await page.screenshot({
+        path: options.screenshot,
+        fullPage: options.fullPage,
+      });
+
+      if (options.dom) {
+        await fs.writeFile(options.dom, html, "utf8");
+      }
+
+      throw error;
     }
-
-    process.stdout.write(`Verified and captured ${options.url}\n`);
   } finally {
     await browser.close();
   }

--- a/tests/e2e_mock_gateway.rs
+++ b/tests/e2e_mock_gateway.rs
@@ -8,7 +8,7 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 
-use support::{with_degraded_app, with_empty_graph_app, with_healthy_app};
+use support::{with_degraded_app, with_empty_graph_app, with_healthy_app, with_smoke_app};
 
 const PAGE_OK: &str = "HTTP/1.1 200 OK";
 const PAGE_ERROR: &str = "Internal Server Error";
@@ -146,12 +146,18 @@ fn healthy_gateway_polished_routes_pass_browser_capture_verification() {
             &["Mission Control", "Gateway status", "Agents graph"],
             &[PAGE_ERROR],
         );
-        app.verify_route_capture(
+        app.verify_route_capture_with_expectations(
             "/agents",
             &agents_png,
             &agents_dom,
             &["Graph View"],
             &["Gateway lookup failed"],
+            &[
+                "[data-sidebar-polish=\"enhanced\"]",
+                "[data-agents-route=\"enhanced\"]",
+            ],
+            &[],
+            std::time::Duration::from_secs(60),
         );
 
         let dashboard_html = fs::read_to_string(&dashboard_dom).expect("read dashboard DOM");
@@ -189,6 +195,52 @@ fn degraded_gateway_polished_dashboard_keeps_shell_and_graph_markers() {
         let dashboard_html = fs::read_to_string(&dom).expect("read degraded dashboard DOM");
         assert!(dashboard_html.contains("data-visual-shell=\"mission-control\""));
         assert!(dashboard_html.contains("data-dashboard-panel=\"gateway\""));
+        assert!(dashboard_html.contains("data-graph-polish=\"enhanced\""));
+
+        let _ = fs::remove_file(&screenshot);
+        let _ = fs::remove_file(&dom);
+    });
+}
+
+#[test]
+#[serial]
+fn poc_smoke_dashboard_shell_and_graph_snapshot_cover_full_vertical_slice() {
+    with_smoke_app(|app| {
+        let event_stream = app.wait_for_gateway_event(
+            &[
+                PAGE_OK,
+                "content-type: text/event-stream",
+                "\"level\":\"healthy\"",
+                "\"summary\":\"Gateway health update: healthy.\"",
+            ],
+            &[],
+        );
+        assert!(event_stream.contains("\"detail\":\"Live gateway event received.\""));
+
+        let screenshot = temp_artifact_path("dashboard-smoke", "png");
+        let dom = temp_artifact_path("dashboard-smoke", "html");
+
+        app.verify_route_capture_with_expectations(
+            "/",
+            &screenshot,
+            &dom,
+            &["Mission Control", "Gateway status", "Agents graph"],
+            &[PAGE_ERROR],
+            &[
+                "[data-visual-shell=\"mission-control\"]",
+                "[data-polish-hero=\"dashboard\"]",
+                "[data-dashboard-panel=\"graph\"]",
+                "[data-graph-polish=\"enhanced\"]",
+            ],
+            &[],
+            std::time::Duration::from_secs(60),
+        );
+
+        let dashboard_html = fs::read_to_string(&dom).expect("read smoke dashboard DOM");
+
+        assert!(dashboard_html.contains("data-visual-shell=\"mission-control\""));
+        assert!(dashboard_html.contains("data-polish-hero=\"dashboard\""));
+        assert!(dashboard_html.contains("data-dashboard-panel=\"graph\""));
         assert!(dashboard_html.contains("data-graph-polish=\"enhanced\""));
 
         let _ = fs::remove_file(&screenshot);

--- a/tests/support/app.rs
+++ b/tests/support/app.rs
@@ -35,6 +35,13 @@ impl BrowserTestApp {
         Self::start(fixture, Some(gateway))
     }
 
+    pub fn smoke() -> Result<Self, String> {
+        let fixture = TestFixture::smoke()?;
+        let gateway = MockGateway::spawn(fixture.gateway_payload.clone())?;
+        fixture.write_openclaw_config(gateway.addr())?;
+        Self::start(fixture, Some(gateway))
+    }
+
     pub fn degraded() -> Result<Self, String> {
         let fixture = TestFixture::degraded()?;
         fixture.write_openclaw_config(SocketAddr::from(([127, 0, 0, 1], pick_unused_port())))?;
@@ -96,6 +103,29 @@ impl BrowserTestApp {
         wait_texts: &[&str],
         forbid_texts: &[&str],
     ) {
+        self.verify_route_capture_with_expectations(
+            route,
+            screenshot,
+            dom,
+            wait_texts,
+            forbid_texts,
+            &[],
+            &[],
+            COMMAND_TIMEOUT,
+        );
+    }
+
+    pub fn verify_route_capture_with_expectations(
+        &mut self,
+        route: &str,
+        screenshot: &str,
+        dom: &str,
+        wait_texts: &[&str],
+        forbid_texts: &[&str],
+        wait_selectors: &[&str],
+        forbid_selectors: &[&str],
+        timeout: std::time::Duration,
+    ) {
         self.process.assert_still_running();
         let mut command = Command::new("node");
         command
@@ -110,20 +140,30 @@ impl BrowserTestApp {
             .arg(screenshot)
             .arg("--dom")
             .arg(dom)
+            .arg("--timeout-ms")
+            .arg(timeout.as_millis().to_string())
             .arg("--full-page");
 
         for text in wait_texts {
             command.arg("--wait-text").arg(text);
         }
 
+        for selector in wait_selectors {
+            command.arg("--wait-selector").arg(selector);
+        }
+
         for text in forbid_texts {
             command.arg("--forbid-text").arg(text);
+        }
+
+        for selector in forbid_selectors {
+            command.arg("--forbid-selector").arg(selector);
         }
 
         run_command_success(
             &mut command,
             &format!("verify live route {route} against the mock gateway"),
-            COMMAND_TIMEOUT,
+            timeout,
         );
     }
 }

--- a/tests/support/fixture.rs
+++ b/tests/support/fixture.rs
@@ -17,6 +17,7 @@ pub(crate) struct GatewayPayload {
     pub(crate) uptime_ms: u64,
     pub(crate) snapshot_ts: u64,
     pub(crate) agents: Vec<MockAgent>,
+    pub(crate) bindings: Vec<Value>,
 }
 
 #[derive(Clone)]
@@ -140,6 +141,83 @@ impl TestFixture {
                         8_400_000,
                     ),
                 ],
+                bindings: vec![],
+            },
+        })
+    }
+
+    pub(crate) fn smoke() -> Result<Self, String> {
+        let tempdir = tempdir().map_err(|error| format!("Could not create tempdir: {error}"))?;
+        let config_path = tempdir.path().join("openclaw.json");
+        let session_root = tempdir.path().join("sessions");
+        fs::create_dir_all(&session_root)
+            .map_err(|error| format!("Could not create session root: {error}"))?;
+
+        let now_ms = now_ms();
+        let main_path = session_root.join("main.json");
+        let calendar_path = session_root.join("calendar.json");
+        let planner_path = session_root.join("planner.json");
+
+        write_session_store(
+            &main_path,
+            &[now_ms - 120_000, now_ms - 240_000, now_ms - 7_200_000],
+        )?;
+        write_session_store(&calendar_path, &[now_ms - 300_000, now_ms - 8_400_000])?;
+        write_session_store(&planner_path, &[now_ms - 8_400_000])?;
+
+        let agents_root = tempdir.path().join("agents");
+        let planner_agent_dir = agents_root.join("planner").join("agent");
+        fs::create_dir_all(&planner_agent_dir)
+            .map_err(|error| format!("Could not create planner agent dir: {error}"))?;
+        fs::write(
+            planner_agent_dir.join("AGENTS.md"),
+            r#"
+### Works With
+- **Main Agent**: For orchestration
+"#,
+        )
+        .map_err(|error| format!("Could not write planner AGENTS.md: {error}"))?;
+
+        Ok(Self {
+            _tempdir: tempdir,
+            config_path,
+            gateway_payload: GatewayPayload {
+                state_version: 64,
+                uptime_ms: 654_321,
+                snapshot_ts: now_ms,
+                agents: vec![
+                    MockAgent::new(
+                        "main",
+                        true,
+                        true,
+                        "120m",
+                        &main_path,
+                        "agent:main:cron:alpha",
+                        120_000,
+                    ),
+                    MockAgent::new(
+                        "calendar",
+                        false,
+                        true,
+                        "120m",
+                        &calendar_path,
+                        "agent:calendar:cron:beta",
+                        300_000,
+                    ),
+                    MockAgent::new(
+                        "planner",
+                        false,
+                        true,
+                        "0m",
+                        &planner_path,
+                        "agent:planner:cron:gamma",
+                        8_400_000,
+                    ),
+                ],
+                bindings: vec![
+                    json!({ "sourceAgentId": "main", "targetAgentId": "calendar" }),
+                    json!({ "sourceAgentId": "calendar", "targetAgentId": "planner" }),
+                ],
             },
         })
     }
@@ -155,6 +233,7 @@ impl TestFixture {
                 uptime_ms: 0,
                 snapshot_ts: now_ms(),
                 agents: vec![],
+                bindings: vec![],
             },
         })
     }
@@ -170,6 +249,7 @@ impl TestFixture {
                 uptime_ms: 4_200,
                 snapshot_ts: now_ms(),
                 agents: vec![],
+                bindings: vec![],
             },
         })
     }
@@ -181,6 +261,14 @@ impl TestFixture {
                 "auth": {
                     "token": AUTH_TOKEN
                 }
+            },
+            "agents": {
+                "list": self.gateway_payload.agents.iter().map(|agent| {
+                    json!({
+                        "id": agent.id,
+                        "name": agent.id,
+                    })
+                }).collect::<Vec<_>>()
             }
         });
         fs::write(

--- a/tests/support/gateway.rs
+++ b/tests/support/gateway.rs
@@ -139,7 +139,8 @@ fn connect_response(request: &Value, payload: &GatewayPayload) -> Value {
                 "health": {
                     "ts": payload.snapshot_ts,
                     "defaultAgentId": "main",
-                    "agents": payload.agents.iter().map(MockAgent::to_value).collect::<Vec<_>>()
+                    "agents": payload.agents.iter().map(MockAgent::to_value).collect::<Vec<_>>(),
+                    "bindings": payload.bindings,
                 }
             }
         }

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -19,6 +19,7 @@ static CLEANUP: OnceLock<()> = OnceLock::new();
 static HEALTHY_APP: OnceLock<Mutex<Option<BrowserTestApp>>> = OnceLock::new();
 static EMPTY_GRAPH_APP: OnceLock<Mutex<Option<BrowserTestApp>>> = OnceLock::new();
 static DEGRADED_APP: OnceLock<Mutex<Option<BrowserTestApp>>> = OnceLock::new();
+static SMOKE_APP: OnceLock<Mutex<Option<BrowserTestApp>>> = OnceLock::new();
 
 pub fn with_healthy_app<T>(f: impl FnOnce(&mut BrowserTestApp) -> T) -> T {
     with_browser_test_app(
@@ -43,6 +44,15 @@ pub fn with_empty_graph_app<T>(f: impl FnOnce(&mut BrowserTestApp) -> T) -> T {
         &EMPTY_GRAPH_APP,
         BrowserTestApp::empty_graph,
         "start empty-graph browser test app",
+        f,
+    )
+}
+
+pub fn with_smoke_app<T>(f: impl FnOnce(&mut BrowserTestApp) -> T) -> T {
+    with_browser_test_app(
+        &SMOKE_APP,
+        BrowserTestApp::smoke,
+        "start smoke browser test app",
         f,
     )
 }
@@ -100,6 +110,7 @@ extern "C" fn cleanup_browser_test_apps() {
     cleanup_browser_test_slot(&HEALTHY_APP);
     cleanup_browser_test_slot(&EMPTY_GRAPH_APP);
     cleanup_browser_test_slot(&DEGRADED_APP);
+    cleanup_browser_test_slot(&SMOKE_APP);
 }
 
 fn cleanup_browser_test_slot(slot: &'static OnceLock<Mutex<Option<BrowserTestApp>>>) {


### PR DESCRIPTION
Task: #33 [POC V1] T7.2 Add end-to-end POC smoke test

Closes #33

## Summary
- add a dedicated mock-gateway smoke fixture and one explicit end-to-end smoke test for the dashboard path
- harden the mock browser verification helper with selector-based waits and failure artifact capture
- keep the smoke path fully mock-backed while validating the dashboard shell and graph surface

## Verification
- npm run build:css
- cargo fmt --all
- cargo check
- cargo test --bin daneel
- cargo test --test e2e_mock_gateway
- cargo test --test e2e_mock_gateway healthy_gateway_polished_routes_pass_browser_capture_verification -- --nocapture
- cargo test --test e2e_mock_gateway poc_smoke_dashboard_shell_and_graph_snapshot_cover_full_vertical_slice -- --nocapture