### PR TITLE
polish: gateway copy, graph session recency, unknown agent cards

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -378,12 +378,13 @@ npm run dev
 
 Then open `/` and verify the card labeled `Gateway status` renders one of:
 
-- `Connected to the OpenClaw Gateway over WebSocket (healthy).`
+- `Connected to the OpenClaw Gateway over WebSocket.` once in the top gateway summary row (not repeated in the detail panel when healthy)
 - a degraded state with a specific gateway/config error message
 
 Known-good healthy render signals:
 
-- badge text `Healthy`
+- summary row: large `Healthy` plus the connection line above
+- detail panel: fetch path, `Gateway URL`, and uptime (no second healthy badge or duplicate headline sentence)
 - `Gateway URL: ws://127.0.0.1:18789/`
 - a live uptime value in milliseconds
 

--- a/src/adapter/openclaw/mapping.rs
+++ b/src/adapter/openclaw/mapping.rs
@@ -7,6 +7,24 @@ use crate::models::{
     runtime::ActiveSessionRecord,
 };
 
+/// Age of the newest entry in `sessions.recent`, matching `gateway::agents::map_session_recency`.
+/// Graph assembly previously omitted this and only merged ages from `snapshot_active_sessions`,
+/// whose fallback ignores sessions outside the short “active” window, so idle agents looked
+/// `Unknown` even when the gateway had recency data here.
+pub(super) fn latest_recent_session_age_ms(agent: &Value) -> Option<u64> {
+    agent
+        .get("sessions")
+        .and_then(|sessions| sessions.get("recent"))
+        .and_then(Value::as_array)
+        .and_then(|entries| entries.first())
+        .and_then(|entry| {
+            entry
+                .get("ageMs")
+                .or_else(|| entry.get("age"))
+                .and_then(Value::as_u64)
+        })
+}
+
 pub(super) fn map_heartbeat(agent: &Value) -> (bool, String) {
     let heartbeat = agent.get("heartbeat").unwrap_or(&Value::Null);
     let enabled = heartbeat
@@ -38,6 +56,12 @@ pub(super) fn map_agent_node(agent: &Value) -> Result<AgentNode, String> {
         .and_then(Value::as_bool)
         .unwrap_or(false);
     let (heartbeat_enabled, heartbeat_schedule) = map_heartbeat(agent);
+    let latest_activity_age_ms = latest_recent_session_age_ms(agent);
+    let status = if latest_activity_age_ms.is_some() {
+        AgentStatus::Idle
+    } else {
+        AgentStatus::Unknown
+    };
 
     Ok(AgentNode {
         id,
@@ -46,8 +70,8 @@ pub(super) fn map_agent_node(agent: &Value) -> Result<AgentNode, String> {
         heartbeat_enabled,
         heartbeat_schedule,
         active_session_count: 0,
-        latest_activity_age_ms: None,
-        status: AgentStatus::Unknown,
+        latest_activity_age_ms,
+        status,
     })
 }
 

--- a/src/adapter/openclaw/snapshot.rs
+++ b/src/adapter/openclaw/snapshot.rs
@@ -83,3 +83,42 @@ pub(super) fn snapshot_active_sessions(
 
     fallback_recent_active_sessions(health)
 }
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::snapshot_active_sessions;
+    use crate::utils::time::ACTIVE_WINDOW_MS;
+
+    /// Documents the gap fixed by reading `sessions.recent` in `map_agent_node`: fallback session
+    /// synthesis intentionally ignores stale recent rows, so graph nodes cannot rely on merge alone.
+    #[test]
+    fn active_session_fallback_omits_recent_sessions_older_than_active_window() {
+        let stale_age = ACTIVE_WINDOW_MS + 9_000;
+        let payload = json!({
+            "snapshot": {
+                "health": {
+                    "agents": [{
+                        "agentId": "quiet-agent",
+                        "sessions": {
+                            "recent": [{
+                                "key": "sess-stale",
+                                "sessionId": "sess-stale",
+                                "age": stale_age
+                            }]
+                        }
+                    }],
+                    "bindings": [],
+                    "activeSessions": []
+                }
+            }
+        });
+
+        let sessions = snapshot_active_sessions(&payload).expect("snapshot active sessions");
+        assert!(
+            sessions.is_empty(),
+            "stale recent session must not appear as an active-session row; graph needs node-level recency"
+        );
+    }
+}

--- a/src/adapter/openclaw/tests.rs
+++ b/src/adapter/openclaw/tests.rs
@@ -18,7 +18,9 @@ use tungstenite::{Message, accept};
 
 use crate::{
     adapter::GatewayAdapter,
+    graph_service::load_graph_snapshot,
     models::graph::{AgentEdgeKind, AgentStatus},
+    utils::time::ACTIVE_WINDOW_MS,
 };
 
 use super::{
@@ -238,6 +240,33 @@ fn openclaw_agent_json_maps_to_agent_node() {
     assert_eq!(node.active_session_count, 0);
     assert_eq!(node.latest_activity_age_ms, None);
     assert_eq!(node.status, AgentStatus::Unknown);
+}
+
+#[test]
+fn openclaw_agent_maps_latest_recent_session_age_from_health_shape() {
+    let node = map_agent_node(&json!({
+        "agentId": "coder",
+        "sessions": {
+            "recent": [{ "key": "sess-1", "age": 420_000 }]
+        }
+    }))
+    .expect("map agent with recent session");
+
+    assert_eq!(node.latest_activity_age_ms, Some(420_000));
+    assert_eq!(node.status, AgentStatus::Idle);
+}
+
+#[test]
+fn openclaw_agent_prefers_age_ms_over_age_in_recent_session() {
+    let node = map_agent_node(&json!({
+        "agentId": "locator",
+        "sessions": {
+            "recent": [{ "key": "a", "age": 100, "ageMs": 99 }]
+        }
+    }))
+    .expect("map agent");
+
+    assert_eq!(node.latest_activity_age_ms, Some(99));
 }
 
 #[test]
@@ -498,6 +527,51 @@ async fn list_agents_reads_nodes_from_gateway_snapshot() {
     assert_eq!(agents[0].heartbeat_schedule, "15m");
     assert_eq!(agents[1].id, "planner");
     assert_eq!(agents[1].name, "planner");
+}
+
+/// End-to-end regression: `snapshot_active_sessions` drops `sessions.recent` rows older than the
+/// active window, so `map_agent_node` must copy that age onto the graph node or the agent becomes
+/// `Unknown` with no recency in the UI.
+#[tokio::test]
+#[serial]
+async fn graph_preserves_stale_recent_session_idle_without_active_session_rows() {
+    let stale_age = ACTIVE_WINDOW_MS + 77_000;
+    let gateway = MockGateway::spawn(gateway_snapshot_payload_with_sessions(
+        json!([{
+            "agentId": "stale-agent",
+            "name": "Stale",
+            "sessions": {
+                "recent": [{
+                    "key": "sess-1",
+                    "sessionId": "sess-1",
+                    "age": stale_age
+                }]
+            }
+        }]),
+        json!([]),
+        json!([]),
+    ))
+    .expect("spawn mock gateway");
+    let tempdir = tempdir().expect("create tempdir");
+    let config_path =
+        write_openclaw_config(tempdir.path(), gateway.addr.port()).expect("write openclaw config");
+    let _guard = EnvVarGuard::set(
+        "OPENCLAW_CONFIG_PATH",
+        config_path.to_str().expect("config path as utf-8"),
+    );
+
+    let snapshot = load_graph_snapshot(&OpenClawAdapter, 42)
+        .await
+        .expect("load graph snapshot");
+
+    let node = snapshot
+        .nodes
+        .iter()
+        .find(|n| n.id == "stale-agent")
+        .expect("stale-agent in snapshot");
+    assert_eq!(node.latest_activity_age_ms, Some(stale_age));
+    assert_eq!(node.active_session_count, 0);
+    assert_eq!(node.status, AgentStatus::Idle);
 }
 
 #[test]

--- a/src/components/agent_node_card.rs
+++ b/src/components/agent_node_card.rs
@@ -12,19 +12,19 @@ const MAX_LABEL_CHARS: usize = 18;
 pub fn AgentNodeCard(node: AgentNode, x: f32, y: f32) -> Element {
     let title = truncated_graph_label(node.name.as_str());
     let monogram = node_monogram(node.name.as_str());
-    let activity = activity_label(&node);
-    let status_text = status_label(&node.status);
+    let show_status_and_latest = node.status != AgentStatus::Unknown;
+    let status_slug = status_data_slug(&node.status);
     let aria_label = format!(
-        "{} agent card, status {}",
+        "{} agent card, {}",
         node.name,
-        status_text.to_lowercase()
+        status_aria_phrase(&node.status)
     );
     let heartbeat = heartbeat_label(&node);
 
     rsx! {
         g {
             "data-agent-node": node.id.as_str(),
-            "data-agent-node-status": status_text.to_lowercase(),
+            "data-agent-node-status": status_slug,
             transform: format!("translate({x} {y})"),
             tabindex: "0",
             "focusable": "true",
@@ -92,22 +92,24 @@ pub fn AgentNodeCard(node: AgentNode, x: f32, y: f32) -> Element {
                 letter_spacing: "0.12em",
                 {heartbeat}
             }
-            text {
-                x: "34",
-                y: "118",
-                fill: "#94a3b8",
-                font_size: "21",
-                font_weight: "700",
-                letter_spacing: "0.16em",
-                {status_text}
-            }
-            text {
-                x: "34",
-                y: "154",
-                fill: "#cbd5e1",
-                font_size: "21",
-                "Latest: "
-                {activity}
+            if show_status_and_latest {
+                text {
+                    x: "34",
+                    y: "118",
+                    fill: "#94a3b8",
+                    font_size: "21",
+                    font_weight: "700",
+                    letter_spacing: "0.16em",
+                    {status_headline(&node.status)}
+                }
+                text {
+                    x: "34",
+                    y: "154",
+                    fill: "#cbd5e1",
+                    font_size: "21",
+                    "Latest: "
+                    {activity_label(&node)}
+                }
             }
             if node.is_default {
                 g { "data-agent-default-badge": node.id.as_str(),
@@ -170,11 +172,30 @@ pub(crate) fn node_signal(status: &AgentStatus) -> &'static str {
     }
 }
 
-pub(crate) fn status_label(status: &AgentStatus) -> &'static str {
+fn status_headline(status: &AgentStatus) -> &'static str {
     match status {
         AgentStatus::Active => "ACTIVE",
         AgentStatus::Idle => "IDLE",
-        AgentStatus::Unknown => "UNKNOWN",
+        AgentStatus::Unknown => "",
+    }
+}
+
+/// Stable `data-agent-node-status` token (kebab-case, no spaces).
+pub(crate) fn status_data_slug(status: &AgentStatus) -> &'static str {
+    match status {
+        AgentStatus::Active => "active",
+        AgentStatus::Idle => "idle",
+        AgentStatus::Unknown => "unknown",
+    }
+}
+
+fn status_aria_phrase(status: &AgentStatus) -> &'static str {
+    match status {
+        AgentStatus::Active => "status active",
+        AgentStatus::Idle => "status idle",
+        AgentStatus::Unknown => {
+            "runtime status not shown; gateway snapshot has no recent session age for this agent"
+        }
     }
 }
 
@@ -291,6 +312,14 @@ mod tests {
         });
 
         assert!(html.contains("this-agent-name-i…"));
-        assert!(html.contains("No recent activity"));
+        assert!(
+            !html.contains("Latest:"),
+            "unknown nodes omit the Latest line"
+        );
+        assert!(html.contains("data-agent-node-status=\"unknown\""));
+        assert!(
+            !html.contains("NO RECENCY") && !html.contains("NO SIGNAL"),
+            "unknown nodes do not show a synthetic status headline"
+        );
     }
 }

--- a/src/gateway/agents.rs
+++ b/src/gateway/agents.rs
@@ -172,7 +172,7 @@ fn map_session_recency(
         .and_then(Value::as_str)
         .map(ToOwned::to_owned);
     let latest_activity_age_ms = recent
-        .and_then(|entry| entry.get("age"))
+        .and_then(|entry| entry.get("ageMs").or_else(|| entry.get("age")))
         .and_then(Value::as_u64);
 
     Ok((

--- a/src/gateway/status.rs
+++ b/src/gateway/status.rs
@@ -61,13 +61,18 @@ pub(crate) fn map_gateway_status_snapshot(
 
     let health = health_status_from_payload(health_frame.payload.as_ref());
 
-    GatewayStatusSnapshot {
-        connected: true,
-        level: health.level(),
-        summary: format!(
+    let summary = match health.state {
+        HealthState::Healthy => "Connected to the OpenClaw Gateway over WebSocket.".to_string(),
+        HealthState::Degraded => format!(
             "Connected to the OpenClaw Gateway over WebSocket ({}).",
             health.label
         ),
+    };
+
+    GatewayStatusSnapshot {
+        connected: true,
+        level: health.level(),
+        summary,
         detail: format!(
             "Gateway status was fetched through the documented loopback WS connection at {}.",
             config.ws_url

--- a/src/graph_service.rs
+++ b/src/graph_service.rs
@@ -178,6 +178,8 @@ fn edge_kind_priority(kind: &AgentEdgeKind) -> u8 {
     }
 }
 
+/// Active sessions win; else if any last-activity age is known (from `sessions.recent` or merged
+/// active-session rows) the agent is idle; else `Unknown` (agent in snapshot without recency).
 fn derive_status(latest_activity_age_ms: Option<u64>, active_session_count: u64) -> AgentStatus {
     if active_session_count > 0 {
         AgentStatus::Active
@@ -209,6 +211,7 @@ mod tests {
         graph::{AgentEdge, AgentEdgeKind, AgentNode, AgentStatus},
         runtime::ActiveSessionRecord,
     };
+    use crate::utils::time::ACTIVE_WINDOW_MS;
     #[cfg(feature = "server")]
     use crate::{
         adapter::GatewayAdapter,
@@ -297,6 +300,32 @@ mod tests {
 
         assert_eq!(snapshot.nodes.len(), 2);
         assert_eq!(snapshot.edges.len(), 1);
+    }
+
+    /// Regression: `snapshot_active_sessions` fallback only keeps recent rows with age inside the
+    /// active window, so agents with older `sessions.recent` ages must still carry
+    /// `latest_activity_age_ms` on the node (from `map_agent_node`) or they collapse to `Unknown`.
+    #[test]
+    fn stale_recent_session_age_stays_idle_when_no_active_session_rows_merge_in() {
+        let stale_ms = ACTIVE_WINDOW_MS + 123_456;
+        let snapshot = assemble_graph_snapshot(
+            assembly_inputs(
+                vec![agent("stale-agent", Some(stale_ms), 0, AgentStatus::Idle)],
+                Vec::new(),
+                Vec::new(),
+                Vec::new(),
+            ),
+            77,
+        );
+
+        let node = snapshot
+            .nodes
+            .iter()
+            .find(|n| n.id == "stale-agent")
+            .expect("stale-agent node");
+        assert_eq!(node.latest_activity_age_ms, Some(stale_ms));
+        assert_eq!(node.active_session_count, 0);
+        assert_eq!(node.status, AgentStatus::Idle);
     }
 
     #[test]

--- a/src/models/graph.rs
+++ b/src/models/graph.rs
@@ -11,6 +11,9 @@ use serde::{Deserialize, Serialize};
 pub enum AgentStatus {
     Active,
     Idle,
+    /// No `latest_activity_age_ms` and no active sessions: the gateway health snapshot listed the
+    /// agent but omitted `sessions.recent` (or its newest entry had no `age` / `ageMs`). Distinct
+    /// from [`Idle`](AgentStatus::Idle), where recency is present.
     Unknown,
 }
 

--- a/src/pages/dashboard.rs
+++ b/src/pages/dashboard.rs
@@ -253,18 +253,13 @@ fn GatewayStatusCard(
 ) -> Element {
     match &*gateway_status.read_unchecked() {
         Some(Ok(snapshot)) => {
-            let badge_class = match snapshot.level {
-                GatewayLevel::Healthy => {
-                    "mt-3 inline-flex rounded-full border border-emerald-300/20 bg-emerald-300/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-emerald-200"
-                }
-                GatewayLevel::Degraded => {
-                    "mt-3 inline-flex rounded-full border border-amber-400/20 bg-amber-400/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-amber-400"
-                }
-            };
+            const DEGRADED_BADGE: &str = "mt-3 inline-flex rounded-full border border-amber-400/20 bg-amber-400/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-amber-400";
 
             rsx! {
-                p { class: "m-0 mt-3 text-sm leading-6 text-slate-300", "{snapshot.summary}" }
-                span { class: badge_class, "{snapshot.level:?}" }
+                if snapshot.level == GatewayLevel::Degraded {
+                    p { class: "m-0 mt-3 text-sm leading-6 text-slate-300", "{snapshot.summary}" }
+                    span { class: DEGRADED_BADGE, "{snapshot.level:?}" }
+                }
                 p { class: "m-0 mt-3 text-xs leading-6 text-slate-300", "{snapshot.detail}" }
                 p { class: "m-0 mt-2 text-xs leading-6 text-slate-300", "Gateway URL: {snapshot.gateway_url}" }
                 if let Some(protocol_version) = snapshot.protocol_version {


### PR DESCRIPTION
## Summary

- **Dashboard:** When the gateway is healthy, the detail card no longer repeats the connection sentence or a second healthy badge (the summary row already shows both).
- **Graph / OpenClaw:** `map_agent_node` now reads `sessions.recent` age (`age` / `ageMs`) so agents with activity older than the active-session fallback window stay **idle** instead of **unknown**, aligned with the agents overview path.
- **Agent overview:** Recent session age accepts `ageMs` or `age`.
- **Agent graph nodes:** For **unknown**, hide the status headline and the entire **Latest:** line; keep `data-agent-node-status=unknown` and a descriptive `aria-label`.
- **Tests:** Unit coverage for graph assembly + snapshot fallback; integration test through `load_graph_snapshot` with a stale recent session and empty `activeSessions`.
- **Docs:** `AGENTS.md` gateway verification notes.

## Verification

- `cargo fmt --all && cargo check && cargo check --features server && cargo test && cargo test --features server`
- `cargo test --test e2e_mock_gateway` (via full `cargo test` runs)