### PR TITLE
feat(skills): introduce github-admin skill with generic CLI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,7 @@ Important files and folders:
 - `src/pages/`: route-level page components
 - `assets/main.css`: app styling
 - `skills/github-admin/`: **Github Admin** skill — use [`skills/github-admin/SKILL.md`](skills/github-admin/SKILL.md) for all GitHub CLI automation (labels, milestones, project board, PRs, issues, releases); Cursor symlink: `.cursor/skills/github-admin`
+- `skills/project-management/`: **Project Management** skill — use [`skills/project-management/SKILL.md`](skills/project-management/SKILL.md) to synchronise GitHub Project board status and post issue comments at each workflow lifecycle checkpoint (`started`, `blocked`, `ready-for-merge`, `done`); Cursor symlink: `.cursor/skills/project-management`
 - `docs/`: requirements, design, and milestone planning
 - `development_setup.md`: local toolchain notes
 
@@ -165,6 +166,8 @@ cargo test
 ## GitHub administration
 
 **Prefer the [`github-admin` skill](skills/github-admin/SKILL.md)** (same content at `.cursor/skills/github-admin`) for any GitHub automation this repo already supports: labels, milestones, project board, issues, pull requests, releases, verification comments, and related maintenance. Read that skill before running commands; it holds invocation, auth, typical examples, PR conventions, approval-prefix guidance, and links to per-command reference files.
+
+**For task lifecycle transitions** (starting work, blocking, opening a PR, closing), use the **[`project-management` skill](skills/project-management/SKILL.md)** instead of calling `set-issue-status` and `comment-issue` by hand. The skill documents the exact command sequence for each event and delegates to `github-admin` for execution.
 
 Do not duplicate those instructions in this guide, and do not replace the skill with ad hoc `curl` or one-off scripts when the CLI covers the work.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,7 +167,7 @@ cargo test
 
 **Prefer the [`github-admin` skill](skills/github-admin/SKILL.md)** (same content at `.cursor/skills/github-admin`) for any GitHub automation this repo already supports: labels, milestones, project board, issues, pull requests, releases, verification comments, and related maintenance. Read that skill before running commands; it holds invocation, auth, typical examples, PR conventions, approval-prefix guidance, and links to per-command reference files.
 
-**For task lifecycle transitions** (starting work, blocking, opening a PR, closing), use the **[`project-management` skill](skills/project-management/SKILL.md)** instead of calling `set-issue-status` and `comment-issue` by hand. The skill documents the exact command sequence for each event and delegates to `github-admin` for execution.
+**For task lifecycle transitions** (starting work, blocking, opening a PR, closing), **spawn a subagent** that reads and follows the **[`project-management` skill](skills/project-management/SKILL.md)**. Pass the event name (`started`, `blocked`, `ready-for-merge`, or `done`) together with the relevant context (issue number, branch, PR number, summary). Never call `set-issue-status` or `comment-issue` directly for lifecycle transitions — delegate to the skill subagent.
 
 Do not duplicate those instructions in this guide, and do not replace the skill with ad hoc `curl` or one-off scripts when the CLI covers the work.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,7 +76,7 @@ Important files and folders:
 - `src/components/`: shared shell UI pieces
 - `src/pages/`: route-level page components
 - `assets/main.css`: app styling
-- `scripts/github-admin.mjs`: GitHub labels, milestones, assignments, and project admin helper
+- `skills/github-admin/`: **Github Admin** skill — use [`skills/github-admin/SKILL.md`](skills/github-admin/SKILL.md) for all GitHub CLI automation (labels, milestones, project board, PRs, issues, releases); Cursor symlink: `.cursor/skills/github-admin`
 - `docs/`: requirements, design, and milestone planning
 - `development_setup.md`: local toolchain notes
 
@@ -162,58 +162,11 @@ Run the Rust test suite:
 cargo test
 ```
 
-## GitHub Administration
+## GitHub administration
 
-Use the dedicated repo admin script for GitHub maintenance instead of ad hoc shell snippets:
+**Prefer the [`github-admin` skill](skills/github-admin/SKILL.md)** (same content at `.cursor/skills/github-admin`) for any GitHub automation this repo already supports: labels, milestones, project board, issues, pull requests, releases, verification comments, and related maintenance. Read that skill before running commands; it holds invocation, auth, typical examples, PR conventions, approval-prefix guidance, and links to per-command reference files.
 
-```bash
-node scripts/github-admin.mjs help
-```
-
-The script reads auth from:
-
-- `GITHUB_TOKEN`
-- `GITHUB_PERSONAL_ACCESS_TOKEN`
-- `~/.env` as a fallback for `GITHUB_PERSONAL_ACCESS_TOKEN`
-
-Typical commands:
-
-```bash
-node scripts/github-admin.mjs sync-labels
-node scripts/github-admin.mjs remap-poc-milestones
-node scripts/github-admin.mjs set-project-status-workflow
-node scripts/github-admin.mjs assign-poc --assignee fcarucci
-node scripts/github-admin.mjs close-implemented --commit 062d615
-node scripts/github-admin.mjs report
-```
-
-There is also an npm alias:
-
-```bash
-npm run github:admin -- help
-```
-
-For pull request creation, use the existing GitHub admin script directly:
-
-```bash
-node scripts/github-admin.mjs create-pr --head <branch> --base main --title "[<Task tag>] Title" --issue <n> --body "<markdown>"
-```
-
-Prefer the direct `node scripts/github-admin.mjs ...` form over npm wrappers for GitHub operations. In this environment that direct node command is the stable approved path and should be used to avoid unnecessary approval friction.
-
-For Codex approval hygiene, prefer the narrow reusable command prefix:
-
-```text
-node scripts/github-admin.mjs
-```
-
-That keeps future GitHub admin actions under a single predictable command instead of repeated approvals for generic scripting commands.
-
-For PR creation specifically, approve this reusable prefix once if your client supports persistent approvals:
-
-```text
-node scripts/github-admin.mjs create-pr
-```
+Do not duplicate those instructions in this guide, and do not replace the skill with ad hoc `curl` or one-off scripts when the CLI covers the work.
 
 ## Run Commands
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,8 +76,8 @@ Important files and folders:
 - `src/components/`: shared shell UI pieces
 - `src/pages/`: route-level page components
 - `assets/main.css`: app styling
-- `skills/github-admin/`: **Github Admin** skill — use [`skills/github-admin/SKILL.md`](skills/github-admin/SKILL.md) for all GitHub CLI automation (labels, milestones, project board, PRs, issues, releases); Cursor symlink: `.cursor/skills/github-admin`
-- `skills/project-management/`: **Project Management** skill — use [`skills/project-management/SKILL.md`](skills/project-management/SKILL.md) to synchronise GitHub Project board status and post issue comments at each workflow lifecycle checkpoint (`started`, `blocked`, `ready-for-merge`, `done`); Cursor symlink: `.cursor/skills/project-management`
+- `skills/github-admin/`: **Github Admin** skill — use [`skills/github-admin/SKILL.md`](skills/github-admin/SKILL.md) for all GitHub CLI automation (labels, milestones, project board, PRs, issues, releases)
+- `skills/project-management/`: **Project Management** skill — use [`skills/project-management/SKILL.md`](skills/project-management/SKILL.md) to synchronise GitHub Project board status and post issue comments at each workflow lifecycle checkpoint (`started`, `blocked`, `ready-for-merge`, `done`)
 - `docs/`: requirements, design, and milestone planning
 - `development_setup.md`: local toolchain notes
 
@@ -165,7 +165,7 @@ cargo test
 
 ## GitHub administration
 
-**Prefer the [`github-admin` skill](skills/github-admin/SKILL.md)** (same content at `.cursor/skills/github-admin`) for any GitHub automation this repo already supports: labels, milestones, project board, issues, pull requests, releases, verification comments, and related maintenance. Read that skill before running commands; it holds invocation, auth, typical examples, PR conventions, approval-prefix guidance, and links to per-command reference files.
+**Prefer the [`github-admin` skill](skills/github-admin/SKILL.md)** for any GitHub automation this repo already supports: labels, milestones, project board, issues, pull requests, releases, verification comments, and related maintenance. Read that skill before running commands; it holds invocation, auth, typical examples, PR conventions, approval-prefix guidance, and links to per-command reference files.
 
 **For task lifecycle transitions** (starting work, blocking, opening a PR, closing), **spawn a subagent** that reads and follows the **[`project-management` skill](skills/project-management/SKILL.md)**. Pass the event name (`started`, `blocked`, `ready-for-merge`, or `done`) together with the relevant context (issue number, branch, PR number, summary). Never call `set-issue-status` or `comment-issue` directly for lifecycle transitions — delegate to the skill subagent.
 

--- a/AGENTS_WORKFLOW.md
+++ b/AGENTS_WORKFLOW.md
@@ -69,19 +69,7 @@ Example:
 [T2.7] Make agent recency and heartbeat state update live
 ```
 
-Use the GitHub admin script directly for PR creation:
-
-```bash
-node scripts/github-admin.mjs create-pr --head <branch> --base main --title "[<Task tag>] Title" --issue <n> --body "<markdown>"
-```
-
-Do not route this through an npm wrapper. In this repo the direct `node scripts/github-admin.mjs ...` command is the intended shortcut and should be preferred to avoid repeated approval prompts.
-
-For approval hygiene, prefer approving this single reusable prefix once:
-
-```text
-node scripts/github-admin.mjs create-pr
-```
+Open the **[`github-admin` skill](skills/github-admin/SKILL.md)** and follow **Pull requests (Daneel task workflow)** (and [references/commands/create-pr.md](skills/github-admin/references/commands/create-pr.md)) for the exact `create-pr` invocation, base branch, body, issue linking, and client approval-prefix guidance. Prefer that skill over copying ad hoc shell snippets into this document.
 
 11. Link the task to the merge request.
 

--- a/AGENTS_WORKFLOW.md
+++ b/AGENTS_WORKFLOW.md
@@ -14,7 +14,9 @@ Examples:
 
 - `task/T2_7`
 
-2. Set the GitHub task status to `In Progress`.
+2. Invoke the **[`project-management` skill](skills/project-management/SKILL.md)** with event **`started`** and the issue number for this task.
+
+   The skill sets the GitHub Project status to `In Progress` and posts a branch comment on the issue.  Read the skill before running commands.
 
 3. Implement the task on the feature branch.
 
@@ -71,9 +73,9 @@ Example:
 
 Open the **[`github-admin` skill](skills/github-admin/SKILL.md)** and follow **Pull requests (Daneel task workflow)** (and [references/commands/create-pr.md](skills/github-admin/references/commands/create-pr.md)) for the exact `create-pr` invocation, base branch, body, issue linking, and client approval-prefix guidance. Prefer that skill over copying ad hoc shell snippets into this document.
 
-11. Link the task to the merge request.
+11. Invoke the **[`project-management` skill](skills/project-management/SKILL.md)** with event **`ready-for-merge`** and the issue + PR numbers.
 
-12. Set the GitHub task status to `Ready for Merge`.
+    The skill sets the GitHub Project status to `Ready for Merge` and calls `link-pr-task` to add the closing keyword to the PR body and a linked-PR comment on the issue.
 
 13. Add relevant implementation notes to the merge request description.
 
@@ -120,5 +122,5 @@ A task is ready for review when:
 - automated tests pass
 - manual visual verification is complete when UI changed
 - branch is pushed
-- merge request is opened and linked to the task
-- GitHub task status is `Ready for Merge`
+- merge request is opened and linked to the task (via `project-management` skill, `ready-for-merge` event)
+- GitHub Project status is `Ready for Merge`

--- a/AGENTS_WORKFLOW.md
+++ b/AGENTS_WORKFLOW.md
@@ -20,7 +20,7 @@ Examples:
 
    ```
    Event:  started
-   Issue:  <ISSUE_NUMBER>
+   Task:   <task-tag-or-title>
    Branch: <BRANCH_NAME>
    ```
 
@@ -87,7 +87,7 @@ Open the **[`github-admin` skill](skills/github-admin/SKILL.md)** and follow **P
 
     ```
     Event:   ready-for-merge
-    Issue:   <ISSUE_NUMBER>
+    Task:    <task-tag-or-title>
     PR:      <PR_NUMBER>
     Summary: <one paragraph: what changed, how tested, known limitations>
     ```

--- a/AGENTS_WORKFLOW.md
+++ b/AGENTS_WORKFLOW.md
@@ -14,9 +14,17 @@ Examples:
 
 - `task/T2_7`
 
-2. Invoke the **[`project-management` skill](skills/project-management/SKILL.md)** with event **`started`** and the issue number for this task.
+2. **Spawn a subagent** to run the **[`project-management` skill](skills/project-management/SKILL.md)** with event **`started`**.
 
-   The skill sets the GitHub Project status to `In Progress` and posts a branch comment on the issue.  Read the skill before running commands.
+   Pass this context to the subagent:
+
+   ```
+   Event:  started
+   Issue:  <ISSUE_NUMBER>
+   Branch: <BRANCH_NAME>
+   ```
+
+   The subagent reads `skills/project-management/SKILL.md`, sets the GitHub Project status to `In Progress`, and posts a branch comment on the issue.
 
 3. Implement the task on the feature branch.
 
@@ -73,9 +81,18 @@ Example:
 
 Open the **[`github-admin` skill](skills/github-admin/SKILL.md)** and follow **Pull requests (Daneel task workflow)** (and [references/commands/create-pr.md](skills/github-admin/references/commands/create-pr.md)) for the exact `create-pr` invocation, base branch, body, issue linking, and client approval-prefix guidance. Prefer that skill over copying ad hoc shell snippets into this document.
 
-11. Invoke the **[`project-management` skill](skills/project-management/SKILL.md)** with event **`ready-for-merge`** and the issue + PR numbers.
+11. **Spawn a subagent** to run the **[`project-management` skill](skills/project-management/SKILL.md)** with event **`ready-for-merge`**.
 
-    The skill sets the GitHub Project status to `Ready for Merge` and calls `link-pr-task` to add the closing keyword to the PR body and a linked-PR comment on the issue.
+    Pass this context to the subagent:
+
+    ```
+    Event:   ready-for-merge
+    Issue:   <ISSUE_NUMBER>
+    PR:      <PR_NUMBER>
+    Summary: <one paragraph: what changed, how tested, known limitations>
+    ```
+
+    The subagent reads `skills/project-management/SKILL.md`, sets the GitHub Project status to `Ready for Merge`, links the PR to the issue, and posts the summary as a comment on the issue.
 
 13. Add relevant implementation notes to the merge request description.
 

--- a/docs/plans/2026-03-26-generic-live-updates.md
+++ b/docs/plans/2026-03-26-generic-live-updates.md
@@ -594,6 +594,28 @@ pub use sse::router;
 
 - [ ] **Delete `src/live.rs`** and update imports in `src/main.rs`. The public API stays the same: `init_live_hub()`, `run_gateway_event_bridge()`, `router()`.
 
+### Step 5: Verify and commit
+
+- [ ] **Run full verification**
+
+```bash
+cargo fmt --all
+cargo check
+cargo check --features server
+cargo test --features server
+cargo test
+```
+
+All existing tests must pass. The old `live::tests` module tests (which tested health parsing) should be migrated to `live::event_parser::tests`.
+
+- [ ] **Commit**
+
+```bash
+git add -A src/models/live_events.rs src/models/mod.rs src/live/
+git rm src/live.rs
+git commit -m "feat(live): generic event system with GatewayEvent enum, parser, and split live modules"
+```
+
 ---
 
 ## Task 2: Browser Integration
@@ -690,6 +712,20 @@ let onmessage = Closure::<dyn FnMut(web_sys::MessageEvent)>::new({
 
 The `onopen` and `onerror` handlers stay exactly as they are — they continue setting `backend_state` and `live_status` directly.
 
+- [ ] **Step 4: Verify and commit**
+
+```bash
+cargo fmt --all
+cargo check
+cargo check --features server
+cargo test
+```
+
+```bash
+git add src/components/live_gateway.rs
+git commit -m "feat(live): expand LiveGatewayProvider to dispatch agent updates from GatewayEvent"
+```
+
 ---
 
 ## Task 3: Agent Updates End-to-End
@@ -755,6 +791,48 @@ In the `AgentCard` component, read from `use_live_gateway()` and render a health
 let live_state = use_live_gateway();
 let live_health = effective_health_indicator(&agent, &live_state);
 // Render a health indicator dot/badge when live_health is Some
+```
+
+- [ ] **Step 3: Run full verification and commit**
+
+```bash
+cargo fmt --all
+cargo check
+cargo check --features server
+cargo test
+cargo test --test e2e_mock_gateway
+```
+
+```bash
+git add tests/support/gateway.rs src/pages/agents.rs
+git commit -m "feat(agents): live agent health updates from gateway events"
+```
+
+---
+
+## Task 4: Refactoring Pass
+
+**Files:** All files touched in Tasks 1-3.
+
+Run the mandatory refactoring skill pass on all touched files.
+
+- [ ] **Step 1: Read and follow `skills/refactoring/SKILL.md`**
+- [ ] **Step 2: Apply refactorings to touched files**
+- [ ] **Step 3: Run full verification**
+
+```bash
+cargo fmt --all
+cargo check
+cargo check --features server
+cargo test
+cargo test --test e2e_mock_gateway
+```
+
+- [ ] **Step 4: Commit any refactoring changes**
+
+```bash
+git add -A
+git commit -m "refactor: post-implementation cleanup for generic live updates"
 ```
 
 ---

--- a/docs/plans/2026-03-26-generic-live-updates.md
+++ b/docs/plans/2026-03-26-generic-live-updates.md
@@ -594,28 +594,6 @@ pub use sse::router;
 
 - [ ] **Delete `src/live.rs`** and update imports in `src/main.rs`. The public API stays the same: `init_live_hub()`, `run_gateway_event_bridge()`, `router()`.
 
-### Step 5: Verify and commit
-
-- [ ] **Run full verification**
-
-```bash
-cargo fmt --all
-cargo check
-cargo check --features server
-cargo test --features server
-cargo test
-```
-
-All existing tests must pass. The old `live::tests` module tests (which tested health parsing) should be migrated to `live::event_parser::tests`.
-
-- [ ] **Commit**
-
-```bash
-git add -A src/models/live_events.rs src/models/mod.rs src/live/
-git rm src/live.rs
-git commit -m "feat(live): generic event system with GatewayEvent enum, parser, and split live modules"
-```
-
 ---
 
 ## Task 2: Browser Integration
@@ -712,20 +690,6 @@ let onmessage = Closure::<dyn FnMut(web_sys::MessageEvent)>::new({
 
 The `onopen` and `onerror` handlers stay exactly as they are — they continue setting `backend_state` and `live_status` directly.
 
-- [ ] **Step 4: Verify and commit**
-
-```bash
-cargo fmt --all
-cargo check
-cargo check --features server
-cargo test
-```
-
-```bash
-git add src/components/live_gateway.rs
-git commit -m "feat(live): expand LiveGatewayProvider to dispatch agent updates from GatewayEvent"
-```
-
 ---
 
 ## Task 3: Agent Updates End-to-End
@@ -791,48 +755,6 @@ In the `AgentCard` component, read from `use_live_gateway()` and render a health
 let live_state = use_live_gateway();
 let live_health = effective_health_indicator(&agent, &live_state);
 // Render a health indicator dot/badge when live_health is Some
-```
-
-- [ ] **Step 3: Run full verification and commit**
-
-```bash
-cargo fmt --all
-cargo check
-cargo check --features server
-cargo test
-cargo test --test e2e_mock_gateway
-```
-
-```bash
-git add tests/support/gateway.rs src/pages/agents.rs
-git commit -m "feat(agents): live agent health updates from gateway events"
-```
-
----
-
-## Task 4: Refactoring Pass
-
-**Files:** All files touched in Tasks 1-3.
-
-Run the mandatory refactoring skill pass on all touched files.
-
-- [ ] **Step 1: Read and follow `skills/refactoring/SKILL.md`**
-- [ ] **Step 2: Apply refactorings to touched files**
-- [ ] **Step 3: Run full verification**
-
-```bash
-cargo fmt --all
-cargo check
-cargo check --features server
-cargo test
-cargo test --test e2e_mock_gateway
-```
-
-- [ ] **Step 4: Commit any refactoring changes**
-
-```bash
-git add -A
-git commit -m "refactor: post-implementation cleanup for generic live updates"
 ```
 
 ---

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "watch:css": "node scripts/watch-css.mjs",
     "dev": "bash scripts/dev.sh 4127 127.0.0.1",
     "start": "bash scripts/dev.sh 4127 127.0.0.1",
-    "github:admin": "node scripts/github-admin.mjs",
+    "github:admin": "node skills/github-admin/scripts/github-admin.mjs",
     "verify:route": "node scripts/verify-route.mjs",
     "verify:dashboard-state": "node scripts/verify-dashboard-state.mjs",
     "verify:live": "node scripts/verify-live.mjs",

--- a/scripts/github-admin.mjs
+++ b/scripts/github-admin.mjs
@@ -166,6 +166,8 @@ Commands:
   create-pr --head <branch> --title <title> [--base <branch>] [--body <text>] [--issue <n>] [--draft]
   update-pr --number <n> [--title <title>] [--body <text>] [--base <branch>] [--state <open|closed>]
   link-pr-task --pr <n> --issue <n> [--close]
+  link-poc-prs [--dry-run]
+  close-poc-project [--dry-run]
   set-project-status-workflow
   set-issue-status --issues <n,n,...> --status <status>
   repair-t0-numbering
@@ -320,6 +322,272 @@ async function allIssues(state = "all") {
 async function allPulls(state = "open") {
   const { owner, repo } = repoParts();
   return rest("GET", `/repos/${owner}/${repo}/pulls?state=${state}&per_page=100`);
+}
+
+async function allPullRequests() {
+  const { owner, repo } = repoParts();
+  const out = [];
+  for (let page = 1; page <= 10; page += 1) {
+    const batch = await rest(
+      "GET",
+      `/repos/${owner}/${repo}/pulls?state=all&per_page=100&page=${page}`,
+    );
+    if (!batch.length) {
+      break;
+    }
+    out.push(...batch);
+    if (batch.length < 100) {
+      break;
+    }
+  }
+  return out;
+}
+
+function pocTaskIdFromIssueTitle(title) {
+  const match = title.match(/\[POC V1\]\s*(T\d+\.\d+)\b/);
+  return match ? match[1] : null;
+}
+
+function pocTaskIdFromPullTitle(title) {
+  const match = title.match(/\b(T\d+\.\d+)\b/);
+  return match ? match[1] : null;
+}
+
+function extractClosingIssueRefsFromText(text) {
+  if (!text) {
+    return [];
+  }
+  const refs = new Set();
+  const re = /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s*:?\s*#(\d+)/gi;
+  let match;
+  while ((match = re.exec(text)) !== null) {
+    refs.add(Number(match[1]));
+  }
+  return [...refs];
+}
+
+function buildPocIssueToPullMap(issues, pulls) {
+  const issueByNum = new Map(issues.map((issue) => [issue.number, issue]));
+  const byIssue = new Map();
+
+  function addCandidate(issueNumber, pullNumber, score, reason) {
+    let inner = byIssue.get(issueNumber);
+    if (!inner) {
+      inner = new Map();
+      byIssue.set(issueNumber, inner);
+    }
+    const prev = inner.get(pullNumber);
+    if (!prev || score > prev.score) {
+      inner.set(pullNumber, { pr: pullNumber, score, reason });
+    }
+  }
+
+  for (const pr of pulls) {
+    const combined = `${pr.title || ""}\n${pr.body || ""}`;
+    for (const num of extractClosingIssueRefsFromText(combined)) {
+      if (!issueByNum.has(num)) {
+        continue;
+      }
+      addCandidate(num, pr.number, 10, "closing-keyword");
+    }
+
+    const prTask = pocTaskIdFromPullTitle(pr.title || "");
+    if (prTask) {
+      for (const iss of issues) {
+        const issueTask = pocTaskIdFromIssueTitle(iss.title);
+        if (issueTask === prTask) {
+          addCandidate(iss.number, pr.number, 8, "task-id");
+        }
+      }
+    }
+  }
+
+  const result = new Map();
+  for (const iss of issues) {
+    const inner = byIssue.get(iss.number);
+    if (!inner?.size) {
+      continue;
+    }
+    const candidates = [...inner.values()];
+    candidates.sort((a, b) => {
+      if (b.score !== a.score) {
+        return b.score - a.score;
+      }
+      return b.pr - a.pr;
+    });
+    result.set(iss.number, candidates[0]);
+  }
+  return result;
+}
+
+function pullBodyClosesIssue(body, issueNumber) {
+  return new RegExp(`(?:close|fix|resolve)[sd]?\\s*:?\\s*#${issueNumber}\\b`, "i").test(
+    body || "",
+  );
+}
+
+function issueHasLinkedPullComment(comments, pullNumber) {
+  const re = new RegExp(`Linked pull request:\\s*\\[#${pullNumber}\\]`, "i");
+  return comments.some((comment) => re.test(comment.body || ""));
+}
+
+async function ensureIssueLinkedToPull(issueNumber, pullNumber, dryRun) {
+  const { owner, repo } = repoParts();
+  const pull = await getPullRequest(pullNumber);
+  const comments = await rest(
+    "GET",
+    `/repos/${owner}/${repo}/issues/${issueNumber}/comments?per_page=100`,
+  );
+
+  let patchedBody = false;
+  let postedComment = false;
+
+  if (!pullBodyClosesIssue(pull.body, issueNumber)) {
+    patchedBody = true;
+    if (!dryRun) {
+      const nextBody = `${pull.body || ""}\n\nCloses #${issueNumber}`.trim();
+      await rest("PATCH", `/repos/${owner}/${repo}/pulls/${pullNumber}`, {
+        body: nextBody,
+      });
+    }
+  }
+
+  if (!issueHasLinkedPullComment(comments, pullNumber)) {
+    postedComment = true;
+    if (!dryRun) {
+      await rest("POST", `/repos/${owner}/${repo}/issues/${issueNumber}/comments`, {
+        body: `Linked pull request: [#${pullNumber}](${pullUrl(pullNumber)})`,
+      });
+    }
+  }
+
+  return { patchedBody, postedComment };
+}
+
+async function linkPocPrs(options) {
+  const dryRun = Boolean(options["dry-run"]);
+  const issues = (await allIssues()).filter(
+    (issue) => !issue.pull_request && issue.title.startsWith("[POC V1] "),
+  );
+  const pulls = await allPullRequests();
+  const map = buildPocIssueToPullMap(issues, pulls);
+
+  const linked = [];
+  const alreadyLinked = [];
+  const unmapped = [];
+
+  for (const issue of issues.sort((a, b) => a.number - b.number)) {
+    const pick = map.get(issue.number);
+    if (!pick) {
+      unmapped.push({
+        number: issue.number,
+        title: issue.title,
+      });
+      continue;
+    }
+
+    const actions = await ensureIssueLinkedToPull(issue.number, pick.pr, dryRun);
+    if (!actions.patchedBody && !actions.postedComment) {
+      alreadyLinked.push({
+        issue: issue.number,
+        pull: pick.pr,
+        reason: pick.reason,
+      });
+      continue;
+    }
+
+    linked.push({
+      issue: issue.number,
+      pull: pick.pr,
+      reason: pick.reason,
+      patchedPullBody: actions.patchedBody,
+      postedIssueComment: actions.postedComment,
+      dryRun,
+    });
+  }
+
+  console.log(
+    JSON.stringify(
+      {
+        dryRun,
+        mappedIssueCount: map.size,
+        pocIssueCount: issues.length,
+        linked,
+        alreadyLinked,
+        unmapped,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+async function closePocProject(options) {
+  const dryRun = Boolean(options["dry-run"]);
+  const data = await projectData();
+  const project = data.user.projectV2;
+  if (!project) {
+    throw new Error(`No project found for user login and number ${projectNumber()}.`);
+  }
+
+  if (project.closed) {
+    console.log(
+      JSON.stringify(
+        {
+          message: "Project is already closed.",
+          number: projectNumber(),
+          title: project.title,
+          closed: project.closed,
+        },
+        null,
+        2,
+      ),
+    );
+    return;
+  }
+
+  if (dryRun) {
+    console.log(
+      JSON.stringify(
+        {
+          dryRun: true,
+          number: projectNumber(),
+          title: project.title,
+          wouldSetClosed: true,
+        },
+        null,
+        2,
+      ),
+    );
+    return;
+  }
+
+  const updated = await graphql(
+    `
+    mutation($projectId: ID!) {
+      updateProjectV2(input: { projectId: $projectId, closed: true }) {
+        projectV2 {
+          id
+          title
+          closed
+        }
+      }
+    }
+    `,
+    { projectId: project.id },
+  );
+
+  console.log(
+    JSON.stringify(
+      {
+        message: "Project closed.",
+        number: projectNumber(),
+        project: updated.updateProjectV2.projectV2,
+      },
+      null,
+      2,
+    ),
+  );
 }
 
 async function allReleases() {
@@ -651,6 +919,7 @@ async function projectData() {
         projectV2(number:$number) {
           id
           title
+          closed
           fields(first:50) {
             nodes {
               ... on ProjectV2FieldCommon {
@@ -1999,6 +2268,8 @@ const commands = {
   "create-pr": () => createPr(options),
   "update-pr": () => updatePr(options),
   "link-pr-task": () => linkPrTask(options),
+  "link-poc-prs": () => linkPocPrs(options),
+  "close-poc-project": () => closePocProject(options),
   "set-project-status-workflow": setProjectStatusWorkflow,
   "set-issue-status": () => setIssueStatus(options),
   "repair-t0-numbering": repairT0Numbering,

--- a/scripts/verify-live.mjs
+++ b/scripts/verify-live.mjs
@@ -314,7 +314,10 @@ async function runCommand(command, args) {
 }
 
 async function runGitHubAdmin(args) {
-  const stdout = await runCommand("node", ["scripts/github-admin.mjs", ...args]);
+  const stdout = await runCommand("node", [
+    "skills/github-admin/scripts/github-admin.mjs",
+    ...args,
+  ]);
   return stdout ? JSON.parse(stdout) : null;
 }
 

--- a/skills/executing-plans/SKILL.md
+++ b/skills/executing-plans/SKILL.md
@@ -24,20 +24,19 @@ Load plan, review critically, execute all tasks, report when complete.
 ### Step 2: Signal work start (project management)
 
 Before touching any code, check whether `skills/project-management/SKILL.md` exists.
+If it does, gather any available context: issue number, branch name, PR number.
 
-**If it exists and the plan names an issue number:**
-
-Spawn a subagent with this context and instruct it to read and follow `skills/project-management/SKILL.md` with event **`started`**:
+Spawn a subagent with the available context and instruct it to read and follow `skills/project-management/SKILL.md` with event **`started`**:
 
 ```
-Issue: <ISSUE_NUMBER>
-Branch: <BRANCH_NAME>
-Event: started
+Event:  started
+Issue:  <ISSUE_NUMBER_if_known>
+Branch: <BRANCH_NAME_if_known>
 ```
 
-The subagent sets the GitHub Project status to `In Progress` and posts a branch comment on the issue.
-
-If the issue number is unknown or the skill file is absent, skip silently and continue.
+The subagent sets the project status to `In Progress` and posts a branch comment.
+Skip any field that is not yet known — the skill handles missing context gracefully.
+If the skill file is absent, skip this step entirely.
 
 ### Step 3: Execute Tasks
 
@@ -58,26 +57,22 @@ After all tasks complete and verified:
 ### Step 5: Signal work complete (project management)
 
 After the PR is opened, check whether `skills/project-management/SKILL.md` exists.
+If it does, gather any available context: issue number, PR number, branch name.
 
-**If it exists and both issue and PR numbers are known:**
+Compose a brief implementation summary covering what changed, how it was tested, and any known limitations or follow-up items.
 
-Compose a brief implementation summary covering:
-- what changed and why
-- how it was tested
-- any known limitations or follow-up items
-
-Spawn a subagent with this context and instruct it to read and follow `skills/project-management/SKILL.md` with event **`ready-for-merge`**:
+Spawn a subagent with the available context and instruct it to read and follow `skills/project-management/SKILL.md` with event **`ready-for-merge`**:
 
 ```
-Issue: <ISSUE_NUMBER>
-PR: <PR_NUMBER>
-Event: ready-for-merge
+Event:   ready-for-merge
+Issue:   <ISSUE_NUMBER_if_known>
+PR:      <PR_NUMBER_if_known>
 Summary: <IMPLEMENTATION_SUMMARY>
 ```
 
-The subagent sets the GitHub Project status to `Ready for Merge`, links the PR to the issue, and posts the summary as a comment on the issue.
-
-If the issue number, PR number, or skill file is absent, skip silently.
+The subagent sets the project status to `Ready for Merge`, links the PR to the issue, and posts the summary as a comment.
+Skip any field that is not yet known — the skill handles missing context gracefully.
+If the skill file is absent, skip this step entirely.
 
 ## When to Stop and Ask for Help
 

--- a/skills/executing-plans/SKILL.md
+++ b/skills/executing-plans/SKILL.md
@@ -21,21 +21,63 @@ Load plan, review critically, execute all tasks, report when complete.
 3. If concerns: Raise them with your human partner before starting
 4. If no concerns: Create a task tracker and proceed
 
-### Step 2: Execute Tasks
+### Step 2: Signal work start (project management)
+
+Before touching any code, check whether `skills/project-management/SKILL.md` exists.
+
+**If it exists and the plan names an issue number:**
+
+Spawn a subagent with this context and instruct it to read and follow `skills/project-management/SKILL.md` with event **`started`**:
+
+```
+Issue: <ISSUE_NUMBER>
+Branch: <BRANCH_NAME>
+Event: started
+```
+
+The subagent sets the GitHub Project status to `In Progress` and posts a branch comment on the issue.
+
+If the issue number is unknown or the skill file is absent, skip silently and continue.
+
+### Step 3: Execute Tasks
 
 For each task:
 1. Mark as in_progress
 2. Follow each step exactly (plan has bite-sized steps)
 3. Run verifications as specified
-4. **End-of-implementation refactoring (mandatory):** run the `refactoring` skill on all files you changed for this task (features **and** bug fixes), then rerun the plan’s fast checks. Do this **proactively**—do not wait for the user to say “refactor.” Ad-hoc tidying while coding does not count.
+4. **End-of-implementation refactoring (mandatory):** run the `refactoring` skill on all files you changed for this task (features **and** bug fixes), then rerun the plan's fast checks. Do this **proactively**—do not wait for the user to say "refactor." Ad-hoc tidying while coding does not count.
 5. Mark as completed
 
-### Step 3: Complete Development
+### Step 4: Complete Development
 
 After all tasks complete and verified:
 - Announce: "I'm using the finishing-a-development-branch skill to complete this work."
 - **REQUIRED SUB-SKILL:** Use `finishing-a-development-branch`
 - Follow that skill to verify tests, present options, execute choice
+
+### Step 5: Signal work complete (project management)
+
+After the PR is opened, check whether `skills/project-management/SKILL.md` exists.
+
+**If it exists and both issue and PR numbers are known:**
+
+Compose a brief implementation summary covering:
+- what changed and why
+- how it was tested
+- any known limitations or follow-up items
+
+Spawn a subagent with this context and instruct it to read and follow `skills/project-management/SKILL.md` with event **`ready-for-merge`**:
+
+```
+Issue: <ISSUE_NUMBER>
+PR: <PR_NUMBER>
+Event: ready-for-merge
+Summary: <IMPLEMENTATION_SUMMARY>
+```
+
+The subagent sets the GitHub Project status to `Ready for Merge`, links the PR to the issue, and posts the summary as a comment on the issue.
+
+If the issue number, PR number, or skill file is absent, skip silently.
 
 ## When to Stop and Ask for Help
 
@@ -69,3 +111,4 @@ After all tasks complete and verified:
 - **`using-git-worktrees`** - REQUIRED: Set up an isolated workspace before starting
 - **`writing-plans`** - Creates the plan this skill executes
 - **`finishing-a-development-branch`** - Complete development after all tasks
+- **`project-management`** - Optional: invoked at start (Step 2) and completion (Step 5) when an issue number is known

--- a/skills/executing-plans/SKILL.md
+++ b/skills/executing-plans/SKILL.md
@@ -24,18 +24,18 @@ Load plan, review critically, execute all tasks, report when complete.
 ### Step 2: Signal work start (project management)
 
 Before touching any code, check whether `skills/project-management/SKILL.md` exists.
-If it does, gather any available context: issue number, branch name, PR number.
+If it does, collect whatever task context is available from the plan and the current workspace.
 
 Spawn a subagent with the available context and instruct it to read and follow `skills/project-management/SKILL.md` with event **`started`**:
 
 ```
 Event:  started
-Issue:  <ISSUE_NUMBER_if_known>
-Branch: <BRANCH_NAME_if_known>
+Task:   <task-id-or-name-from-plan>
+Branch: <current-branch-name>
 ```
 
-The subagent sets the project status to `In Progress` and posts a branch comment.
-Skip any field that is not yet known — the skill handles missing context gracefully.
+The subagent is responsible for finding any associated work item and updating its status.
+Omit fields that are not yet known — the skill handles missing context gracefully.
 If the skill file is absent, skip this step entirely.
 
 ### Step 3: Execute Tasks
@@ -57,7 +57,7 @@ After all tasks complete and verified:
 ### Step 5: Signal work complete (project management)
 
 After the PR is opened, check whether `skills/project-management/SKILL.md` exists.
-If it does, gather any available context: issue number, PR number, branch name.
+If it does, collect whatever context is available from the completed work.
 
 Compose a brief implementation summary covering what changed, how it was tested, and any known limitations or follow-up items.
 
@@ -65,13 +65,14 @@ Spawn a subagent with the available context and instruct it to read and follow `
 
 ```
 Event:   ready-for-merge
-Issue:   <ISSUE_NUMBER_if_known>
-PR:      <PR_NUMBER_if_known>
+Task:    <task-id-or-name-from-plan>
+Branch:  <branch-name>
+PR:      <pr-number-if-known>
 Summary: <IMPLEMENTATION_SUMMARY>
 ```
 
-The subagent sets the project status to `Ready for Merge`, links the PR to the issue, and posts the summary as a comment.
-Skip any field that is not yet known — the skill handles missing context gracefully.
+The subagent is responsible for finding any associated work item, updating its status, and posting the summary.
+Omit fields that are not yet known — the skill handles missing context gracefully.
 If the skill file is absent, skip this step entirely.
 
 ## When to Stop and Ask for Help
@@ -106,4 +107,4 @@ If the skill file is absent, skip this step entirely.
 - **`using-git-worktrees`** - REQUIRED: Set up an isolated workspace before starting
 - **`writing-plans`** - Creates the plan this skill executes
 - **`finishing-a-development-branch`** - Complete development after all tasks
-- **`project-management`** - Optional: invoked at start (Step 2) and completion (Step 5) when an issue number is known
+- **`project-management`** - Optional: invoked at start (Step 2) and completion (Step 5) with task context

--- a/skills/github-admin/SKILL.md
+++ b/skills/github-admin/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: github-admin
+description: Runs the Daneel GitHub admin CLI for labels, milestones, project board sync, issues, pull requests, releases, and review threads against the GitHub REST and GraphQL APIs. Use when the user or workflow needs GitHub repository or project maintenance, creating or updating PRs and issues (including bodies from files), syncing labels or milestones, posting verification comments, or any task matching the commands in this skill's reference.
+---
+
+# Github Admin
+
+## Prefer this skill first
+
+Repository guides point here on purpose: **load this file before** running GitHub maintenance for Daneel. Use [reference.md](reference.md) and only the [references/commands/](references/commands/) pages you need so context stays small. Do not improvise ad hoc `curl`, throwaway `/tmp` API scripts, or **new domain-specific subcommands** in `github-admin.mjs` (e.g. per-plan or per-project issue generators). Prefer **generic** commands (`create-issue`, `create-project`, `update-issue`, `delete-issue`, `list-prs`, `project`, etc.) and drive GitHub **directly** when you need one-off edits—do not wire repo markdown plans into the admin script for that.
+
+Use this skill when an agent should perform **repository automation** or **project management** for the Daneel project via the checked-in Node script instead of manual UI steps or raw API experiments.
+
+## Authentication and configuration
+
+Details: [references/environment.md](references/environment.md).
+
+- **Token:** `GITHUB_TOKEN` or `GITHUB_PERSONAL_ACCESS_TOKEN`; optional fallback from `~/.env` (`export GITHUB_PERSONAL_ACCESS_TOKEN=…`) per script `envFileToken()`.
+- **`GITHUB_REPOSITORY`:** default `fcarucci/daneel`.
+- **`GITHUB_PROJECT_NUMBER`:** default `1` (GraphQL project helpers).
+
+For large issue bodies, use **`create-issue`** / **`update-issue`** with `--body-file <path>` instead of inlining markdown in the shell (see [references/commands/create-issue.md](references/commands/create-issue.md) and [update-issue.md](references/commands/update-issue.md)).
+
+## How to run the CLI
+
+From the repository root:
+
+```bash
+node skills/github-admin/scripts/github-admin.mjs <command> [options]
+```
+
+- `help` (or no command) — print full usage (exit 0 for `help`).
+
+**npm:** `npm run github:admin -- <command> [options]` runs the same script. For **Codex or similar clients** where approvals are per command prefix, prefer the **`node skills/github-admin/scripts/github-admin.mjs …`** form so one narrow prefix covers all subcommands instead of repeated generic `npm` approvals.
+
+**Approval hygiene (optional):** Approve a single reusable prefix once if your client supports it:
+
+```text
+node skills/github-admin/scripts/github-admin.mjs
+```
+
+For PR creation only:
+
+```text
+node skills/github-admin/scripts/github-admin.mjs create-pr
+```
+
+## Typical maintenance commands
+
+```bash
+node skills/github-admin/scripts/github-admin.mjs help
+node skills/github-admin/scripts/github-admin.mjs sync-labels
+node skills/github-admin/scripts/github-admin.mjs list-issues --limit 50
+node skills/github-admin/scripts/github-admin.mjs report
+```
+
+Adjust flags and SHAs to the task at hand; full command list: [reference.md](reference.md).
+
+## Pull requests (Daneel task workflow)
+
+Align PR titles with the repository task workflow: **`[<Task tag>] Title`**, for example `[T2.7] Make agent recency and heartbeat state update live`.
+
+Create a PR (default base `main`; link issue when applicable):
+
+```bash
+node skills/github-admin/scripts/github-admin.mjs create-pr --head <branch> --base main --title "[<Task tag>] Title" --issue <n> --body "<markdown>"
+```
+
+See [references/commands/create-pr.md](references/commands/create-pr.md) for all flags. After opening the PR, link the task to the merge request and set project status per your workflow doc.
+
+## Command reference
+
+- **Index:** [reference.md](reference.md) → per-command files under [`references/commands/`](references/commands/).
+- **Script mechanics:** [references/script.md](references/script.md).
+- **Environment:** [references/environment.md](references/environment.md).
+
+**When adding commands or flags:** update `usage()` in `skills/github-admin/scripts/github-admin.mjs`, add or edit `references/commands/<command>.md`, and update the index in [reference.md](reference.md) if the command set changes.

--- a/skills/github-admin/reference.md
+++ b/skills/github-admin/reference.md
@@ -1,0 +1,54 @@
+# Github Admin CLI — reference index
+
+Authoritative behavior: `skills/github-admin/scripts/github-admin.mjs`. **When changing commands or flags:** update `usage()` in that file, the matching file under [`references/commands/`](references/commands/), and this index if command names are added or removed.
+
+## Shared docs (small context)
+
+- [Script: parser, flags, help](references/script.md)
+- [Environment variables](references/environment.md)
+
+## Grouped commands
+
+Commands with `--action` dispatching:
+
+| Command | Doc |
+|---------|-----|
+| `issue-comment` | [issue-comment.md](references/commands/issue-comment.md) |
+| `project` | [project.md](references/commands/project.md) |
+| `pr-review` | [pr-review.md](references/commands/pr-review.md) |
+| `release-asset` | [release-asset.md](references/commands/release-asset.md) |
+
+## Commands
+
+| Command | Doc |
+|---------|-----|
+| `comment-issue` | [comment-issue.md](references/commands/comment-issue.md) |
+| `comment-pr` | [comment-pr.md](references/commands/comment-pr.md) |
+| `comment-pr-verification` | [comment-pr-verification.md](references/commands/comment-pr-verification.md) |
+| `create-issue` | [create-issue.md](references/commands/create-issue.md) |
+| `create-project` | [create-project.md](references/commands/create-project.md) |
+| `create-pr` | [create-pr.md](references/commands/create-pr.md) |
+| `delete-issue` | [delete-issue.md](references/commands/delete-issue.md) |
+| `ensure-release` | [ensure-release.md](references/commands/ensure-release.md) |
+| `link-pr-task` | [link-pr-task.md](references/commands/link-pr-task.md) |
+| `list-issues` | [list-issues.md](references/commands/list-issues.md) |
+| `list-prs` | [list-prs.md](references/commands/list-prs.md) |
+| `list-tasks` | [list-tasks.md](references/commands/list-tasks.md) |
+| `merge-pr` | [merge-pr.md](references/commands/merge-pr.md) |
+| `report` | [report.md](references/commands/report.md) |
+| `set-issue-status` | [set-issue-status.md](references/commands/set-issue-status.md) |
+| `set-project-visibility` | [set-project-visibility.md](references/commands/set-project-visibility.md) |
+| `sync-labels` | [sync-labels.md](references/commands/sync-labels.md) |
+| `update-issue` | [update-issue.md](references/commands/update-issue.md) |
+| `update-pr` | [update-pr.md](references/commands/update-pr.md) |
+| `upload-release-asset` | [upload-release-asset.md](references/commands/upload-release-asset.md) |
+
+## Completing or closing work (generic pattern)
+
+There are no repo-specific “complete issue” commands. Use:
+
+1. [comment-issue.md](references/commands/comment-issue.md) (or `comment-pr`) to post an implementation note with commit link.
+2. [update-issue.md](references/commands/update-issue.md) `--state closed` when the issue should close.
+3. [set-issue-status.md](references/commands/set-issue-status.md) if the issue is on the configured Project and you need a Status column update (e.g. `Done`).
+
+To find issues by title, use [list-issues.md](references/commands/list-issues.md) with `--title-prefix` or `--title-contains`.

--- a/skills/github-admin/reference.md
+++ b/skills/github-admin/reference.md
@@ -30,6 +30,7 @@ Commands with `--action` dispatching:
 | `create-pr` | [create-pr.md](references/commands/create-pr.md) |
 | `delete-issue` | [delete-issue.md](references/commands/delete-issue.md) |
 | `ensure-release` | [ensure-release.md](references/commands/ensure-release.md) |
+| `label-issue` | [label-issue.md](references/commands/label-issue.md) |
 | `link-pr-task` | [link-pr-task.md](references/commands/link-pr-task.md) |
 | `list-issues` | [list-issues.md](references/commands/list-issues.md) |
 | `list-prs` | [list-prs.md](references/commands/list-prs.md) |

--- a/skills/github-admin/reference.md
+++ b/skills/github-admin/reference.md
@@ -28,6 +28,7 @@ Commands with `--action` dispatching:
 | `create-issue` | [create-issue.md](references/commands/create-issue.md) |
 | `create-project` | [create-project.md](references/commands/create-project.md) |
 | `create-pr` | [create-pr.md](references/commands/create-pr.md) |
+| `get-issue` | [get-issue.md](references/commands/get-issue.md) |
 | `delete-issue` | [delete-issue.md](references/commands/delete-issue.md) |
 | `ensure-release` | [ensure-release.md](references/commands/ensure-release.md) |
 | `label-issue` | [label-issue.md](references/commands/label-issue.md) |

--- a/skills/github-admin/references/commands/comment-issue.md
+++ b/skills/github-admin/references/commands/comment-issue.md
@@ -1,0 +1,14 @@
+# comment-issue
+
+Adds a comment on an issue or pull request (GitHub uses the same issues API for PR comments).
+
+```bash
+node skills/github-admin/scripts/github-admin.mjs comment-issue --number <n> --body <text>
+```
+
+| Flag | Required |
+|------|----------|
+| `--number` | Yes |
+| `--body` | Yes |
+
+**Alias:** `comment-pr` — same implementation and flags.

--- a/skills/github-admin/references/commands/comment-pr-verification.md
+++ b/skills/github-admin/references/commands/comment-pr-verification.md
@@ -1,0 +1,16 @@
+# comment-pr-verification
+
+```bash
+node skills/github-admin/scripts/github-admin.mjs comment-pr-verification --number <n> --artifact-url <url> [--route <route>] [--latest-session-count <n>] [--connected-ribbon <true|false>] [--screenshot <path>] [--dom <path>] [--video <path>]
+```
+
+| Flag | Required | Notes |
+|------|----------|-------|
+| `--number` | Yes | Pull request number |
+| `--artifact-url` | Yes | URL to verification artifact; alias `artifactUrl` in code |
+| `--route` | No | Default `/agents` |
+| `--latest-session-count` | No | Alias `latestSessionCount` in code |
+| `--connected-ribbon` | No | `true` or `false`; alias `connectedRibbon` in code |
+| `--screenshot` | No | Path or URL note for screenshot |
+| `--dom` | No | Path or URL note for DOM snapshot |
+| `--video` | No | Local path to recorded video (included in comment text) |

--- a/skills/github-admin/references/commands/comment-pr.md
+++ b/skills/github-admin/references/commands/comment-pr.md
@@ -1,0 +1,12 @@
+# comment-pr
+
+**Alias of** [comment-issue.md](comment-issue.md): same handler. Adds a comment on the given number (issue or pull request).
+
+```bash
+node skills/github-admin/scripts/github-admin.mjs comment-pr --number <n> --body <text>
+```
+
+| Flag | Required | Notes |
+|------|----------|-------|
+| `--number` | Yes | Issue or PR number |
+| `--body` | Yes | Comment body (markdown) |

--- a/skills/github-admin/references/commands/create-issue.md
+++ b/skills/github-admin/references/commands/create-issue.md
@@ -1,0 +1,14 @@
+# create-issue
+
+```bash
+node skills/github-admin/scripts/github-admin.mjs create-issue --title <title> [--body <text>] [--body-file <path>] [--labels <a,b,c>] [--milestone <n>] [--assignees <login,login>]
+```
+
+| Flag | Required | Notes |
+|------|----------|-------|
+| `--title` | Yes | |
+| `--body` | No | Mutually exclusive with `--body-file` |
+| `--body-file` | No | UTF-8 file path for description; mutually exclusive with `--body` |
+| `--labels` | No | Comma-separated |
+| `--milestone` | No | Milestone number |
+| `--assignees` | No | Comma-separated GitHub logins |

--- a/skills/github-admin/references/commands/create-pr.md
+++ b/skills/github-admin/references/commands/create-pr.md
@@ -1,0 +1,14 @@
+# create-pr
+
+```bash
+node skills/github-admin/scripts/github-admin.mjs create-pr --head <branch> --title <title> [--base <branch>] [--body <text>] [--issue <n>] [--draft]
+```
+
+| Flag | Required | Notes |
+|------|----------|-------|
+| `--head` | Yes | Source branch |
+| `--title` | Yes | PR title |
+| `--base` | No | Default `main` |
+| `--body` | No | Description |
+| `--issue` | No | Related issue number |
+| `--draft` | No | Boolean: open as draft |

--- a/skills/github-admin/references/commands/create-project.md
+++ b/skills/github-admin/references/commands/create-project.md
@@ -1,0 +1,15 @@
+# create-project
+
+Creates a GitHub **ProjectV2** owned by the **owner of `GITHUB_REPOSITORY`** (user or organization). The GitHub `createProjectV2` mutation does not set visibility, so this command immediately follows creation with `updateProjectV2` **`public: true`** unless you pass **`--private`**.
+
+```bash
+node skills/github-admin/scripts/github-admin.mjs create-project --title <title> [--private] [--dry-run]
+```
+
+| Flag | Description |
+|------|-------------|
+| `--title` | Project title (required). |
+| `--private` | Skip the public step; leave the project at GitHub’s default visibility for new projects. |
+| `--dry-run` | Print intended owner kind and whether the project would be made public; no mutation. |
+
+Requires token scopes that can create projects for that owner and update project settings.

--- a/skills/github-admin/references/commands/delete-issue.md
+++ b/skills/github-admin/references/commands/delete-issue.md
@@ -1,0 +1,11 @@
+# delete-issue
+
+Deletes a **repository issue** by number (GraphQL `deleteIssue`). Does not delete pull requests.
+
+```bash
+node skills/github-admin/scripts/github-admin.mjs delete-issue --number <n>
+```
+
+| Flag | Required |
+|------|----------|
+| `--number` | Yes |

--- a/skills/github-admin/references/commands/ensure-release.md
+++ b/skills/github-admin/references/commands/ensure-release.md
@@ -1,0 +1,13 @@
+# ensure-release
+
+```bash
+node skills/github-admin/scripts/github-admin.mjs ensure-release --tag <tag> [--name <title>] [--body <text>] [--draft] [--prerelease]
+```
+
+| Flag | Required | Notes |
+|------|----------|-------|
+| `--tag` | Yes | Git tag |
+| `--name` | No | Release title |
+| `--body` | No | Release notes |
+| `--draft` | No | Boolean: presence enables draft |
+| `--prerelease` | No | Boolean: presence enables prerelease |

--- a/skills/github-admin/references/commands/get-issue.md
+++ b/skills/github-admin/references/commands/get-issue.md
@@ -1,0 +1,13 @@
+# get-issue
+
+Fetches a single issue (or pull request) by number and prints its title, state, labels, milestone, and assignees as JSON. Works on both issue and PR numbers since GitHub's REST API exposes PRs through the issues endpoint.
+
+```bash
+node skills/github-admin/scripts/github-admin.mjs get-issue --number <n>
+```
+
+| Flag | Required | Notes |
+|------|----------|-------|
+| `--number` | Yes | Issue or pull request number |
+
+**Output fields:** `number`, `title`, `state`, `labels[]`, `milestone` (`number` + `title`), `assignees[]`, `url`, `isPullRequest`.

--- a/skills/github-admin/references/commands/get-issue.md
+++ b/skills/github-admin/references/commands/get-issue.md
@@ -1,6 +1,6 @@
 # get-issue
 
-Fetches a single issue (or pull request) by number and prints its title, state, labels, milestone, and assignees as JSON. Works on both issue and PR numbers since GitHub's REST API exposes PRs through the issues endpoint.
+Fetches a single issue (or pull request) by number and prints its title, body, state, labels, milestone, and assignees as JSON. Works on both issue and PR numbers since GitHub's REST API exposes PRs through the issues endpoint.
 
 ```bash
 node skills/github-admin/scripts/github-admin.mjs get-issue --number <n>
@@ -10,4 +10,4 @@ node skills/github-admin/scripts/github-admin.mjs get-issue --number <n>
 |------|----------|-------|
 | `--number` | Yes | Issue or pull request number |
 
-**Output fields:** `number`, `title`, `state`, `labels[]`, `milestone` (`number` + `title`), `assignees[]`, `url`, `isPullRequest`.
+**Output fields:** `number`, `title`, `body`, `state`, `labels[]`, `milestone` (`number` + `title`), `assignees[]`, `url`, `isPullRequest`.

--- a/skills/github-admin/references/commands/issue-comment.md
+++ b/skills/github-admin/references/commands/issue-comment.md
@@ -1,0 +1,12 @@
+# issue-comment
+
+```bash
+node skills/github-admin/scripts/github-admin.mjs issue-comment --action list --issue <n>
+node skills/github-admin/scripts/github-admin.mjs issue-comment --action delete --comment-id <n>
+```
+
+| Flag | Required | Notes |
+|------|----------|-------|
+| `--action` | Yes | `list` or `delete` |
+| `--issue` | For `list` | Issue number |
+| `--comment-id` | For `delete` | Comment id; alias `commentId` in implementation |

--- a/skills/github-admin/references/commands/label-issue.md
+++ b/skills/github-admin/references/commands/label-issue.md
@@ -1,0 +1,15 @@
+# label-issue
+
+Adds or removes labels on an issue **without replacing the full label set**. Use this instead of `update-issue --labels` when you want to touch only specific labels and preserve the rest.
+
+```bash
+node skills/github-admin/scripts/github-admin.mjs label-issue --action add --number <n> --labels <a,b,...>
+node skills/github-admin/scripts/github-admin.mjs label-issue --action remove --number <n> --label <name>
+```
+
+| Flag | Required | Notes |
+|------|----------|-------|
+| `--action` | Yes | `add` or `remove` |
+| `--number` | Yes | Issue number |
+| `--labels` | For `add` | Comma-separated label names to add |
+| `--label` | For `remove` | Single label name to remove |

--- a/skills/github-admin/references/commands/link-pr-task.md
+++ b/skills/github-admin/references/commands/link-pr-task.md
@@ -1,0 +1,11 @@
+# link-pr-task
+
+```bash
+node skills/github-admin/scripts/github-admin.mjs link-pr-task --pr <n> --issue <n> [--close]
+```
+
+| Flag | Required | Notes |
+|------|----------|-------|
+| `--pr` | Yes | Pull request number |
+| `--issue` | Yes | Issue number |
+| `--close` | No | Boolean: add closing semantics when appropriate |

--- a/skills/github-admin/references/commands/list-issues.md
+++ b/skills/github-admin/references/commands/list-issues.md
@@ -1,0 +1,28 @@
+# list-issues
+
+Lists repository issues (not pull requests), with optional filters. Paginates up to 50 GitHub API pages (100 issues per page).
+
+```bash
+node skills/github-admin/scripts/github-admin.mjs list-issues [--state <open|closed|all>] [--title-prefix <text>] [--title-contains <text>] [--limit <n>]
+```
+
+| Flag | Required | Default | Notes |
+|------|----------|---------|-------|
+| `--state` | No | `all` | `open`, `closed`, or `all` |
+| `--title-prefix` | No | | Issue title must start with this string |
+| `--title-contains` | No | | Substring match on title |
+| `--limit` | No | `500` | Max issues after filtering (cap 2000) |
+
+**Example (task lookup by title prefix):**
+
+```bash
+node skills/github-admin/scripts/github-admin.mjs list-issues --title-prefix "[T2.7]"
+```
+
+**Example (list all open issues):**
+
+```bash
+node skills/github-admin/scripts/github-admin.mjs list-issues --state open --limit 200
+```
+
+Compare output to your local task doc manually, or script outside this CLI.

--- a/skills/github-admin/references/commands/list-prs.md
+++ b/skills/github-admin/references/commands/list-prs.md
@@ -1,0 +1,9 @@
+# list-prs
+
+```bash
+node skills/github-admin/scripts/github-admin.mjs list-prs [--state <open|closed|all>]
+```
+
+| Flag | Required | Notes |
+|------|----------|-------|
+| `--state` | No | Default `open` |

--- a/skills/github-admin/references/commands/list-tasks.md
+++ b/skills/github-admin/references/commands/list-tasks.md
@@ -1,0 +1,11 @@
+# list-tasks
+
+Lists pending issues from the configured GitHub Project board, sorted by priority then issue number. Excludes items in `In Progress`, `Done`, or `Ready for Merge` status — shows only `Ready` and `Backlog` items.
+
+```bash
+node skills/github-admin/scripts/github-admin.mjs list-tasks [--limit <n>]
+```
+
+| Flag | Required | Notes |
+|------|----------|-------|
+| `--limit` | No | Max items returned; default `10` |

--- a/skills/github-admin/references/commands/merge-pr.md
+++ b/skills/github-admin/references/commands/merge-pr.md
@@ -1,0 +1,12 @@
+# merge-pr
+
+```bash
+node skills/github-admin/scripts/github-admin.mjs merge-pr --number <n> [--method <merge|squash|rebase>] [--title <title>] [--message <text>]
+```
+
+| Flag | Required | Notes |
+|------|----------|-------|
+| `--number` | Yes | Pull request number |
+| `--method` | No | Default `merge` |
+| `--title` | No | Merge commit title |
+| `--message` | No | Merge commit message |

--- a/skills/github-admin/references/commands/pr-review.md
+++ b/skills/github-admin/references/commands/pr-review.md
@@ -1,0 +1,12 @@
+# pr-review
+
+```bash
+node skills/github-admin/scripts/github-admin.mjs pr-review --action list --number <n>
+node skills/github-admin/scripts/github-admin.mjs pr-review --action resolve --thread-id <id>
+```
+
+| Flag | Required | Notes |
+|------|----------|-------|
+| `--action` | Yes | `list` or `resolve` |
+| `--number` | For `list` | Pull request number |
+| `--thread-id` | For `resolve` | Review thread id; alias `threadId` in implementation |

--- a/skills/github-admin/references/commands/project.md
+++ b/skills/github-admin/references/commands/project.md
@@ -1,0 +1,19 @@
+# project
+
+Project automation: link PRs to their tracked issues, or close the configured GitHub Project. Supports `[--dry-run]` on both actions.
+
+```bash
+node skills/github-admin/scripts/github-admin.mjs project --action link-prs [--title-prefix <text>] [--dry-run]
+node skills/github-admin/scripts/github-admin.mjs project --action close-project [--dry-run]
+```
+
+| Flag | Required | Notes |
+|------|----------|-------|
+| `--action` | Yes | `link-prs` or `close-project` |
+| `--title-prefix` | No | For `link-prs`: restrict to issues whose title starts with this string |
+| `--dry-run` | No | Report what would happen without making changes |
+
+| `--action` | Description |
+|------------|-------------|
+| `link-prs` | Matches issues to PRs (by task id or closing keywords) and ensures each issue has a `Closes #n` in the PR body and a linked-PR comment on the issue |
+| `close-project` | Closes the configured GitHub Project (`GITHUB_PROJECT_NUMBER`) |

--- a/skills/github-admin/references/commands/release-asset.md
+++ b/skills/github-admin/references/commands/release-asset.md
@@ -1,0 +1,12 @@
+# release-asset
+
+```bash
+node skills/github-admin/scripts/github-admin.mjs release-asset --action list --tag <tag>
+node skills/github-admin/scripts/github-admin.mjs release-asset --action delete --asset-id <n>
+```
+
+| Flag | Required | Notes |
+|------|----------|-------|
+| `--action` | Yes | `list` or `delete` |
+| `--tag` | For `list` | Release tag |
+| `--asset-id` | For `delete` | Asset id; alias `assetId` in implementation |

--- a/skills/github-admin/references/commands/report.md
+++ b/skills/github-admin/references/commands/report.md
@@ -1,0 +1,7 @@
+# report
+
+```bash
+node skills/github-admin/scripts/github-admin.mjs report
+```
+
+Prints JSON summary: repository, configured project v2 (title, item count, fields), total issue count, and milestones. No additional flags.

--- a/skills/github-admin/references/commands/set-issue-status.md
+++ b/skills/github-admin/references/commands/set-issue-status.md
@@ -1,0 +1,10 @@
+# set-issue-status
+
+```bash
+node skills/github-admin/scripts/github-admin.mjs set-issue-status --issues <n,n,...> --status <status>
+```
+
+| Flag | Required | Notes |
+|------|----------|-------|
+| `--issues` | Yes | Comma-separated issue numbers |
+| `--status` | Yes | Project Status field value name |

--- a/skills/github-admin/references/commands/set-project-visibility.md
+++ b/skills/github-admin/references/commands/set-project-visibility.md
@@ -1,0 +1,17 @@
+# set-project-visibility
+
+Sets visibility on a **user** GitHub Project (classic Projects are not supported here). Uses the repository owner from `GITHUB_REPOSITORY` as the user login and `GITHUB_PROJECT_NUMBER` as the default project number unless `--number` is set.
+
+```bash
+node skills/github-admin/scripts/github-admin.mjs set-project-visibility --public [--number <n>] [--dry-run]
+node skills/github-admin/scripts/github-admin.mjs set-project-visibility --private [--number <n>] [--dry-run]
+```
+
+| Flag | Description |
+|------|-------------|
+| `--public` | Make the project visible to everyone (mutually exclusive with `--private`). |
+| `--private` | Restrict the project (mutually exclusive with `--public`). |
+| `--number` | Project number (default: `GITHUB_PROJECT_NUMBER`, usually `1`). |
+| `--dry-run` | Print the current project metadata and the intended visibility change; no mutation. |
+
+Requires a token with permission to update the project (GraphQL `updateProjectV2`).

--- a/skills/github-admin/references/commands/sync-labels.md
+++ b/skills/github-admin/references/commands/sync-labels.md
@@ -1,0 +1,7 @@
+# sync-labels
+
+```bash
+node skills/github-admin/scripts/github-admin.mjs sync-labels
+```
+
+Ensures the repository label set matches the definitions embedded in the script (`LABEL_DEFS`). Creates any missing labels and updates color/description for existing ones. No additional flags.

--- a/skills/github-admin/references/commands/update-issue.md
+++ b/skills/github-admin/references/commands/update-issue.md
@@ -1,0 +1,14 @@
+# update-issue
+
+```bash
+node skills/github-admin/scripts/github-admin.mjs update-issue --number <n> [--title <title>] [--body <text>] [--body-file <path>] [--state <open|closed>] [--labels <a,b,c>]
+```
+
+| Flag | Required | Notes |
+|------|----------|-------|
+| `--number` | Yes | Issue number |
+| `--title` | No | |
+| `--body` | No | Mutually exclusive with `--body-file` |
+| `--body-file` | No | UTF-8 file path for new body; mutually exclusive with `--body` |
+| `--state` | No | `open` or `closed` |
+| `--labels` | No | Comma-separated label names |

--- a/skills/github-admin/references/commands/update-issue.md
+++ b/skills/github-admin/references/commands/update-issue.md
@@ -1,7 +1,7 @@
 # update-issue
 
 ```bash
-node skills/github-admin/scripts/github-admin.mjs update-issue --number <n> [--title <title>] [--body <text>] [--body-file <path>] [--state <open|closed>] [--labels <a,b,c>]
+node skills/github-admin/scripts/github-admin.mjs update-issue --number <n> [--title <title>] [--body <text>] [--body-file <path>] [--state <open|closed>] [--labels <a,b,c>] [--assignees <login,login>]
 ```
 
 | Flag | Required | Notes |
@@ -12,3 +12,4 @@ node skills/github-admin/scripts/github-admin.mjs update-issue --number <n> [--t
 | `--body-file` | No | UTF-8 file path for new body; mutually exclusive with `--body` |
 | `--state` | No | `open` or `closed` |
 | `--labels` | No | Comma-separated label names |
+| `--assignees` | No | Comma-separated assignees logins |

--- a/skills/github-admin/references/commands/update-issue.md
+++ b/skills/github-admin/references/commands/update-issue.md
@@ -1,7 +1,7 @@
 # update-issue
 
 ```bash
-node skills/github-admin/scripts/github-admin.mjs update-issue --number <n> [--title <title>] [--body <text>] [--body-file <path>] [--state <open|closed>] [--labels <a,b,c>] [--assignees <login,login>]
+node skills/github-admin/scripts/github-admin.mjs update-issue --number <n> [--title <title>] [--body <text>] [--body-file <path>] [--state <open|closed>] [--labels <a,b,c>] [--assignees <login,login>] [--milestone <n>]
 ```
 
 | Flag | Required | Notes |
@@ -13,3 +13,4 @@ node skills/github-admin/scripts/github-admin.mjs update-issue --number <n> [--t
 | `--state` | No | `open` or `closed` |
 | `--labels` | No | Comma-separated label names |
 | `--assignees` | No | Comma-separated assignees logins |
+| `--milestone` | No | Positive repository milestone number |

--- a/skills/github-admin/references/commands/update-pr.md
+++ b/skills/github-admin/references/commands/update-pr.md
@@ -1,0 +1,13 @@
+# update-pr
+
+```bash
+node skills/github-admin/scripts/github-admin.mjs update-pr --number <n> [--title <title>] [--body <text>] [--base <branch>] [--state <open|closed>]
+```
+
+| Flag | Required | Notes |
+|------|----------|-------|
+| `--number` | Yes | Pull request number |
+| `--title` | No | |
+| `--body` | No | |
+| `--base` | No | Retarget base branch |
+| `--state` | No | `open` or `closed` |

--- a/skills/github-admin/references/commands/upload-release-asset.md
+++ b/skills/github-admin/references/commands/upload-release-asset.md
@@ -1,0 +1,11 @@
+# upload-release-asset
+
+```bash
+node skills/github-admin/scripts/github-admin.mjs upload-release-asset --tag <tag> --file <path> [--label <text>]
+```
+
+| Flag | Required | Notes |
+|------|----------|-------|
+| `--tag` | Yes | Existing release tag |
+| `--file` | Yes | Local file path to upload |
+| `--label` | No | Display label for the asset |

--- a/skills/github-admin/references/environment.md
+++ b/skills/github-admin/references/environment.md
@@ -1,0 +1,11 @@
+# Github Admin — environment variables
+
+Used by `skills/github-admin/scripts/github-admin.mjs`. **Keep aligned with `usage()`** when defaults change.
+
+| Variable | Required | Default / notes |
+|----------|----------|------------------|
+| `GITHUB_TOKEN` or `GITHUB_PERSONAL_ACCESS_TOKEN` | Yes (or token in `~/.env`) | `Authorization: token …` |
+| `GITHUB_REPOSITORY` | No | `fcarucci/daneel` |
+| `GITHUB_PROJECT_NUMBER` | No | `1` |
+
+Token fallback: script reads `GITHUB_PERSONAL_ACCESS_TOKEN` from `~/.env` when exported in shell form (`export GITHUB_PERSONAL_ACCESS_TOKEN=…`).

--- a/skills/github-admin/references/script.md
+++ b/skills/github-admin/references/script.md
@@ -1,0 +1,26 @@
+# Github Admin — script behavior
+
+Implementation: `skills/github-admin/scripts/github-admin.mjs`.
+
+**Maintenance:** When adding or changing commands or flags, update `usage()` in that file, the matching file under [`commands/`](commands/), and the command list in [`../reference.md`](../reference.md).
+
+## Invocation
+
+```text
+node skills/github-admin/scripts/github-admin.mjs <command> [options]
+```
+
+```bash
+node skills/github-admin/scripts/github-admin.mjs help
+```
+
+## Argument parser
+
+- Flags are `--name` with an optional value: if the next argv token does not start with `--`, it becomes the value; otherwise the flag is boolean `true`.
+- Some hyphenated flags also accept camelCase keys in code (e.g. `--comment-id` / `commentId`). See each command file under [`commands/`](commands/).
+
+## Boolean vs value flags
+
+**Boolean (presence = true):** `--dry-run`, `--draft`, `--prerelease`, `--close` (where that command documents `--close`), `--public`, `--private` (for `set-project-visibility` or `create-project` to keep a new project non-public).
+
+**Value flags:** `--action`, `--assignee`, `--limit`, `--issue`, `--comment-id`, `--number`, `--title`, `--body`, `--body-file`, `--state`, `--labels`, `--milestone`, `--assignees`, `--tag`, `--name`, `--file`, `--label`, `--artifact-url`, `--route`, `--latest-session-count`, `--connected-ribbon`, `--screenshot`, `--dom`, `--video`, `--title-prefix`, `--title-contains`, `--asset-id`, `--thread-id`, `--method`, `--message`, `--head`, `--base`, `--issues`, `--status`, `--commit`, `--note`, `--pr`.

--- a/skills/github-admin/scripts/github-admin.mjs
+++ b/skills/github-admin/scripts/github-admin.mjs
@@ -28,153 +28,35 @@ const LABEL_DEFS = {
   enhancement: { color: "a2eeef", description: "New feature or improvement" },
 };
 
-const OLD_MILESTONE_TITLES = [
-  "P0 Foundation Decisions",
-  "P1 App Bootstrap",
-  "P2 Server Function Backbone",
-  "P3 OpenClaw Adapter Minimum Slice",
-  "P4 Graph Assembly Service",
-  "P5 Vertical UI Slice",
-  "P6 Error Handling And Polish",
-  "P7 End-To-End Proof",
-];
-
-const POC_MILESTONES = [
-  {
-    title: "POC V1 Foundation",
-    description:
-      "Core product framing, app bootstrap, and first end-to-end gateway/server-function connectivity. Covers the baseline shell, styling system, shared models, and the initial OpenClaw connection path.",
-  },
-  {
-    title: "POC V1 Graph Backbone",
-    description:
-      "Data-layer work for turning OpenClaw state into graph-ready application data. Covers adapter slices, bindings, active sessions, relationship hints, graph semantics, and graph snapshot assembly.",
-  },
-  {
-    title: "POC V1 Operator Experience",
-    description:
-      "UI completion, graph presentation, error handling, polish, and POC validation. Covers the dashboard and agents surface, visual graph work, refresh flows, smoke tests, and demo readiness.",
-  },
-];
-
-const PHASE_PRIORITY = {
-  "Foundation Decisions": "priority/p0",
-  "App Bootstrap": "priority/p0",
-  "Server Function Backbone": "priority/p0",
-  "OpenClaw Adapter Minimum Slice": "priority/p0",
-  "Graph Assembly Service": "priority/p1",
-  "Vertical UI Slice": "priority/p1",
-  "Error Handling And Polish": "priority/p2",
-  "End-To-End Proof": "priority/p2",
-};
-
-const PHASE_MILESTONE = {
-  "Foundation Decisions": "POC V1 Foundation",
-  "App Bootstrap": "POC V1 Foundation",
-  "Server Function Backbone": "POC V1 Foundation",
-  "OpenClaw Adapter Minimum Slice": "POC V1 Graph Backbone",
-  "Graph Assembly Service": "POC V1 Graph Backbone",
-  "Vertical UI Slice": "POC V1 Operator Experience",
-  "Error Handling And Polish": "POC V1 Operator Experience",
-  "End-To-End Proof": "POC V1 Operator Experience",
-};
-
-const IMPLEMENTED_ISSUES = {
-  5: {
-    title: "T1.1 Create the Rust/Dioxus application skeleton",
-    body:
-      "the runnable Rust/Dioxus application skeleton\n- the crate manifest and Dioxus app metadata\n- `src/main.rs` app entrypoint\n- the initial router shell used by the app",
-  },
-  6: {
-    title: "T1.2 Add the base route structure",
-    body:
-      "typed routes for `/`, `/agents`, and `/settings`\n- a shared application layout\n- persistent sidebar navigation and top bar\n- a safe not-found route",
-  },
-  7: {
-    title: "T1.3 Add design tokens and global styling",
-    body:
-      "the Tailwind 4 styling pipeline\n- shared design tokens and custom mission-control styling\n- panel, typography, spacing, border, and surface treatments\n- the generated application stylesheet served through Dioxus",
-  },
-  9: {
-    title: "T2.1 Add the first live gateway connectivity slice",
-    body:
-      "the first live Dioxus server-backed gateway slice\n- a server-side loopback WebSocket connection to the OpenClaw Gateway\n- a small typed gateway status payload rendered in the UI\n- degraded/error handling when config or connectivity fails",
-  },
-  12: {
-    title: "T2.4 Add the first Dioxus server function",
-    body:
-      "the first Dioxus server function, `get_gateway_status()`\n- dashboard-side resource loading for that server function\n- user-visible loading, healthy, and degraded rendering states",
-  },
-  15: {
-    title: "T3.2 Implement gateway configuration loading",
-    body:
-      "gateway config loading from `~/.openclaw/openclaw.json`\n- parsing of `gateway.port`\n- parsing of `gateway.auth.token`\n- actionable degraded states when config is missing or invalid",
-  },
-  16: {
-    title: "T3.3 Implement `gateway_status()`",
-    body:
-      "a gateway health/status call over the documented WebSocket path\n- mapping into the shared `GatewayStatusSnapshot` model\n- healthy vs degraded UI presentation on the dashboard and status pill",
-  },
-  24: {
-    title: "T5.1 Build the dashboard shell",
-    body:
-      "the dashboard route shell\n- the hero status area\n- the gateway status card\n- adjacent dashboard panels that reserve space for the graph-focused surface\n- loading/error/success states around the gateway-backed summary area",
-  },
-};
-
-const T0_IMPLEMENTED_ISSUES = {
-  1: {
-    comment:
-      "the Phase 0 foundation note in `docs/milestones/proof-of-concept-1/t0_foundation_decisions.md`\n- explicit node, edge, status, and provenance semantics for the POC graph\n- clear guidance on what the UI may and may not claim from the underlying data",
-  },
-  2: {
-    comment:
-      "the Phase 0 foundation note in `docs/milestones/proof-of-concept-1/t0_foundation_decisions.md`\n- the minimal `GatewayAdapter` capability contract for the first slice\n- the initial shared model surface the adapter should stabilize for later implementation work",
-  },
-  4: {
-    comment:
-      "the Phase 0 foundation note in `docs/milestones/proof-of-concept-1/t0_foundation_decisions.md`\n- the deterministic SVG rendering decision for POC V1\n- layout and verification constraints that keep the first graph slice stable and testable",
-  },
-};
 
 function usage() {
   console.log(`Usage:
-  node scripts/github-admin.mjs <command> [options]
+  node skills/github-admin/scripts/github-admin.mjs <command> [options]
 
 Commands:
   sync-labels
-  assign-poc [--assignee <login>]
-  remap-poc-milestones
-  reconcile-poc-doc
-  find-task --task <Tn.n>
+  list-issues [--state <open|closed|all>] [--title-prefix <text>] [--title-contains <text>] [--limit <n>]
   list-tasks [--limit <n>]
-  list-issue-comments --issue <n>
-  delete-issue-comment --comment-id <n>
-  update-issue --number <n> [--title <title>] [--body <text>] [--state <open|closed>] [--labels <a,b,c>]
-  create-issue --title <title> [--body <text>] [--labels <a,b,c>] [--milestone <n>] [--assignees <login,login>]
-  list-open-prs
-  list-prs [--state <open|closed|all>]
-  comment-pr --number <n> --body <text>
+  issue-comment --action <list|delete> (list: --issue <n>; delete: --comment-id <n>)
+  update-issue --number <n> [--title <title>] [--body <text>] [--body-file <path>] [--state <open|closed>] [--labels <a,b,c>]
+  create-issue --title <title> [--body <text>] [--body-file <path>] [--labels <a,b,c>] [--milestone <n>] [--assignees <login,login>]
+  create-project --title <title> [--private] [--dry-run]   (ProjectV2 owned by GITHUB_REPOSITORY owner; public by default)
+  delete-issue --number <n>
+  list-prs [--state <open|closed|all>]   (default: open)
+  comment-issue --number <n> --body <text>
+  comment-pr --number <n> --body <text>   (alias: same as comment-issue; works for PRs)
   ensure-release --tag <tag> [--name <title>] [--body <text>] [--draft] [--prerelease]
   upload-release-asset --tag <tag> --file <path> [--label <text>]
   comment-pr-verification --number <n> --artifact-url <url> [--route <route>] [--latest-session-count <n>] [--connected-ribbon <true|false>] [--screenshot <path>] [--dom <path>]
-  list-release-assets --tag <tag>
-  delete-release-asset --asset-id <n>
-  list-pr-review-threads --number <n>
-  resolve-pr-review-thread --thread-id <id>
+  release-asset --action <list|delete> (list: --tag <tag>; delete: --asset-id <n>)
+  pr-review --action <list|resolve> (list: --number <n>; resolve: --thread-id <id>)
   merge-pr --number <n> [--method <merge|squash|rebase>] [--title <title>] [--message <text>]
   create-pr --head <branch> --title <title> [--base <branch>] [--body <text>] [--issue <n>] [--draft]
   update-pr --number <n> [--title <title>] [--body <text>] [--base <branch>] [--state <open|closed>]
   link-pr-task --pr <n> --issue <n> [--close]
-  link-poc-prs [--dry-run]
-  close-poc-project [--dry-run]
-  set-project-status-workflow
+  project --action <link-prs|close-project> [--title-prefix <text>] [--dry-run]
+  set-project-visibility --public|--private [--number <n>] [--dry-run]   (user ProjectV2; default number from GITHUB_PROJECT_NUMBER)
   set-issue-status --issues <n,n,...> --status <status>
-  repair-t0-numbering
-  audit-poc-consistency
-  complete-issue --issue <n> --commit <sha> --note <text>
-  complete-t0 --commit <sha>
-  close-implemented [--commit <sha>]
   report
 
 Environment:
@@ -343,12 +225,12 @@ async function allPullRequests() {
   return out;
 }
 
-function pocTaskIdFromIssueTitle(title) {
-  const match = title.match(/\[POC V1\]\s*(T\d+\.\d+)\b/);
+function taskIdFromIssueTitle(title) {
+  const match = title.match(/\b(T\d+\.\d+)\b/);
   return match ? match[1] : null;
 }
 
-function pocTaskIdFromPullTitle(title) {
+function taskIdFromPullTitle(title) {
   const match = title.match(/\b(T\d+\.\d+)\b/);
   return match ? match[1] : null;
 }
@@ -366,7 +248,7 @@ function extractClosingIssueRefsFromText(text) {
   return [...refs];
 }
 
-function buildPocIssueToPullMap(issues, pulls) {
+function buildIssueToPullMap(issues, pulls) {
   const issueByNum = new Map(issues.map((issue) => [issue.number, issue]));
   const byIssue = new Map();
 
@@ -391,10 +273,10 @@ function buildPocIssueToPullMap(issues, pulls) {
       addCandidate(num, pr.number, 10, "closing-keyword");
     }
 
-    const prTask = pocTaskIdFromPullTitle(pr.title || "");
+    const prTask = taskIdFromPullTitle(pr.title || "");
     if (prTask) {
       for (const iss of issues) {
-        const issueTask = pocTaskIdFromIssueTitle(iss.title);
+        const issueTask = taskIdFromIssueTitle(iss.title);
         if (issueTask === prTask) {
           addCandidate(iss.number, pr.number, 8, "task-id");
         }
@@ -464,13 +346,15 @@ async function ensureIssueLinkedToPull(issueNumber, pullNumber, dryRun) {
   return { patchedBody, postedComment };
 }
 
-async function linkPocPrs(options) {
+async function linkPrs(options) {
   const dryRun = Boolean(options["dry-run"]);
-  const issues = (await allIssues()).filter(
-    (issue) => !issue.pull_request && issue.title.startsWith("[POC V1] "),
-  );
+  const titlePrefix = options["title-prefix"] || null;
+  let issues = (await allIssues()).filter((issue) => !issue.pull_request);
+  if (titlePrefix) {
+    issues = issues.filter((issue) => issue.title.startsWith(titlePrefix));
+  }
   const pulls = await allPullRequests();
-  const map = buildPocIssueToPullMap(issues, pulls);
+  const map = buildIssueToPullMap(issues, pulls);
 
   const linked = [];
   const alreadyLinked = [];
@@ -511,7 +395,7 @@ async function linkPocPrs(options) {
       {
         dryRun,
         mappedIssueCount: map.size,
-        pocIssueCount: issues.length,
+        issueCount: issues.length,
         linked,
         alreadyLinked,
         unmapped,
@@ -522,7 +406,7 @@ async function linkPocPrs(options) {
   );
 }
 
-async function closePocProject(options) {
+async function closeProject(options) {
   const dryRun = Boolean(options["dry-run"]);
   const data = await projectData();
   const project = data.user.projectV2;
@@ -687,92 +571,6 @@ async function allMilestones() {
   return rest("GET", `/repos/${owner}/${repo}/milestones?state=all&per_page=100`);
 }
 
-function parsePocTasks(markdown) {
-  const lines = markdown.split("\n");
-  let phase = null;
-  const tasks = new Map();
-
-  for (const line of lines) {
-    if (line.startsWith("# Phase ")) {
-      phase = line.split(":", 2)[1].trim();
-      continue;
-    }
-    const match = line.match(/^## (T\d+\.\d+) (.+)$/);
-    if (match && phase) {
-      const title = `[POC V1] ${match[1]} ${match[2].trim()}`;
-      tasks.set(title, { phase, taskId: match[1] });
-    }
-  }
-
-  return tasks;
-}
-
-function taskIdFromTitle(title) {
-  const match = title.match(/^\[POC V1\] (T\d+\.\d+) /);
-  return match ? match[1] : null;
-}
-
-function parseNumberedSection(markdown, heading) {
-  const escapedHeading = heading.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const match = markdown.match(
-    new RegExp(`## ${escapedHeading}\\n\\n([\\s\\S]*?)(?:\\n## |\\n# |$)`),
-  );
-  if (!match) {
-    return [];
-  }
-
-  return match[1]
-    .split("\n")
-    .map((line) => line.trim())
-    .filter((line) => /^\d+\.\s+T\d+\.\d+$/.test(line))
-    .map((line) => {
-      const [, number, taskId] = line.match(/^(\d+)\.\s+(T\d+\.\d+)$/);
-      return { number: Number(number), taskId };
-    });
-}
-
-function addUnique(list, item) {
-  if (!list.includes(item)) {
-    list.push(item);
-  }
-}
-
-function labelsForTask(phase, title) {
-  const labels = ["poc-v1", "task", PHASE_PRIORITY[phase]];
-  const titleLower = title.toLowerCase();
-
-  if (phase === "Foundation Decisions") {
-    addUnique(labels, "design");
-    if (titleLower.includes("graph")) addUnique(labels, "graph");
-    if (titleLower.includes("adapter")) addUnique(labels, "adapter");
-    if (titleLower.includes("fixture") || titleLower.includes("test")) addUnique(labels, "testing");
-  } else if (phase === "App Bootstrap") {
-    addUnique(labels, "frontend");
-    if (titleLower.includes("test")) addUnique(labels, "testing");
-  } else if (phase === "Server Function Backbone") {
-    addUnique(labels, "backend");
-    addUnique(labels, "gateway");
-    if (titleLower.includes("event bridge")) addUnique(labels, "frontend");
-  } else if (phase === "OpenClaw Adapter Minimum Slice") {
-    addUnique(labels, "backend");
-    addUnique(labels, "adapter");
-    addUnique(labels, "gateway");
-  } else if (phase === "Graph Assembly Service") {
-    addUnique(labels, "backend");
-    addUnique(labels, "graph");
-  } else if (phase === "Vertical UI Slice") {
-    addUnique(labels, "frontend");
-    addUnique(labels, "graph");
-  } else if (phase === "Error Handling And Polish") {
-    addUnique(labels, "frontend");
-    if (titleLower.includes("connection") || titleLower.includes("refresh")) addUnique(labels, "gateway");
-  } else if (phase === "End-To-End Proof") {
-    addUnique(labels, "testing");
-    if (titleLower.includes("adapter")) addUnique(labels, "adapter");
-  }
-
-  return labels;
-}
 
 async function syncLabels() {
   const { owner, repo } = repoParts();
@@ -791,93 +589,9 @@ async function syncLabels() {
     }
   }
 
-  const tasks = parsePocTasks(
-    await readFile("docs/milestones/proof-of-concept-1/poc_v1_task_breakdown.md", "utf8"),
-  );
-  const issues = (await allIssues()).filter(
-    (issue) => !issue.pull_request && tasks.has(issue.title),
-  );
-
-  for (const issue of issues) {
-    const { phase } = tasks.get(issue.title);
-    await rest("PATCH", `/repos/${owner}/${repo}/issues/${issue.number}`, {
-      labels: labelsForTask(phase, issue.title),
-    });
-  }
-
-  console.log(`Synced ${Object.keys(LABEL_DEFS).length} labels and relabeled ${issues.length} POC issues.`);
+  console.log(`Synced ${Object.keys(LABEL_DEFS).length} labels.`);
 }
 
-async function ensureMilestones() {
-  const { owner, repo } = repoParts();
-  const existing = await allMilestones();
-  const byTitle = new Map(existing.map((milestone) => [milestone.title, milestone]));
-  const created = new Map();
-
-  for (const spec of POC_MILESTONES) {
-    if (byTitle.has(spec.title)) {
-      created.set(
-        spec.title,
-        await rest("PATCH", `/repos/${owner}/${repo}/milestones/${byTitle.get(spec.title).number}`, {
-          title: spec.title,
-          description: spec.description,
-          state: "open",
-        }),
-      );
-    } else {
-      created.set(spec.title, await rest("POST", `/repos/${owner}/${repo}/milestones`, spec));
-    }
-  }
-
-  return created;
-}
-
-async function remapPocMilestones() {
-  const { owner, repo } = repoParts();
-  const tasks = parsePocTasks(
-    await readFile("docs/milestones/proof-of-concept-1/poc_v1_task_breakdown.md", "utf8"),
-  );
-  const milestones = await ensureMilestones();
-  const issues = (await allIssues()).filter(
-    (issue) => !issue.pull_request && tasks.has(issue.title),
-  );
-
-  for (const issue of issues) {
-    const { phase } = tasks.get(issue.title);
-    const milestone = milestones.get(PHASE_MILESTONE[phase]);
-    await rest("PATCH", `/repos/${owner}/${repo}/issues/${issue.number}`, {
-      milestone: milestone.number,
-    });
-  }
-
-  const freshMilestones = await allMilestones();
-  const stillUsed = new Set(
-    (await allIssues()).filter((issue) => !issue.pull_request && issue.milestone).map((issue) => issue.milestone.title),
-  );
-  for (const milestone of freshMilestones) {
-    if (OLD_MILESTONE_TITLES.includes(milestone.title) && !stillUsed.has(milestone.title)) {
-      await rest("DELETE", `/repos/${owner}/${repo}/milestones/${milestone.number}`);
-    }
-  }
-
-  console.log(`Reassigned ${issues.length} POC issues into ${POC_MILESTONES.length} milestones.`);
-}
-
-async function assignPoc(options) {
-  const { owner, repo } = repoParts();
-  const assignee = options.assignee || owner;
-  const issues = (await allIssues()).filter(
-    (issue) => !issue.pull_request && issue.title.startsWith("[POC V1] "),
-  );
-
-  for (const issue of issues) {
-    await rest("PATCH", `/repos/${owner}/${repo}/issues/${issue.number}`, {
-      assignees: [assignee],
-    });
-  }
-
-  console.log(`Assigned ${issues.length} POC issues to ${assignee}.`);
-}
 
 async function addIssueToProject(projectId, contentId) {
   const data = await graphql(
@@ -897,6 +611,198 @@ async function addIssueToProject(projectId, contentId) {
   );
 
   return data.addProjectV2ItemById.item.id;
+}
+
+function resolveUserProjectNumberArg(raw) {
+  if (raw == null || raw === "") {
+    return projectNumber();
+  }
+  const n = Number(raw);
+  if (!Number.isInteger(n) || n < 1) {
+    throw new Error("set-project-visibility --number must be a positive integer.");
+  }
+  return n;
+}
+
+async function fetchUserProjectV2Summary(overrideNumber) {
+  const { owner } = repoParts();
+  const number = resolveUserProjectNumberArg(overrideNumber);
+  const data = await graphql(
+    `
+    query($owner:String!, $number:Int!) {
+      user(login:$owner) {
+        projectV2(number:$number) {
+          id
+          title
+          public
+          url
+          closed
+        }
+      }
+    }
+    `,
+    { owner, number },
+  );
+  return { project: data.user.projectV2, number };
+}
+
+async function setProjectVisibility(options) {
+  const dryRun = Boolean(options["dry-run"]);
+  const wantPublic = Boolean(options.public);
+  const wantPrivate = Boolean(options.private);
+  if (wantPublic === wantPrivate) {
+    throw new Error(
+      "set-project-visibility requires exactly one of --public or --private.",
+    );
+  }
+  const { project, number } = await fetchUserProjectV2Summary(options.number);
+  if (!project) {
+    throw new Error(
+      `No user ProjectV2 found for login and number ${number}. Check GITHUB_REPOSITORY owner and --number.`,
+    );
+  }
+  if (dryRun) {
+    console.log(
+      JSON.stringify(
+        {
+          dryRun: true,
+          wouldSetPublic: wantPublic,
+          project: {
+            id: project.id,
+            title: project.title,
+            public: project.public,
+            url: project.url,
+            closed: project.closed,
+          },
+        },
+        null,
+        2,
+      ),
+    );
+    return;
+  }
+  const updated = await graphql(
+    `
+    mutation($projectId: ID!, $public: Boolean!) {
+      updateProjectV2(input: { projectId: $projectId, public: $public }) {
+        projectV2 {
+          id
+          title
+          public
+          url
+          closed
+        }
+      }
+    }
+    `,
+    { projectId: project.id, public: wantPublic },
+  );
+  console.log(
+    JSON.stringify({ project: updated.updateProjectV2.projectV2 }, null, 2),
+  );
+}
+
+async function fetchRepositoryOwnerNodeId() {
+  const { owner, repo } = repoParts();
+  const data = await graphql(
+    `
+    query($owner: String!, $name: String!) {
+      repository(owner: $owner, name: $name) {
+        owner {
+          __typename
+          id
+        }
+      }
+    }
+    `,
+    { owner, name: repo },
+  );
+  const ownerNode = data.repository?.owner;
+  if (!ownerNode?.id) {
+    throw new Error(
+      `Could not resolve owner id for repository ${owner}/${repo}.`,
+    );
+  }
+  return { ownerId: ownerNode.id, ownerTypename: ownerNode.__typename };
+}
+
+async function createProjectCommand(options) {
+  const dryRun = Boolean(options["dry-run"]);
+  const title = String(options.title || "").trim();
+  if (!title) {
+    throw new Error("create-project requires --title <text>.");
+  }
+  const stayPrivate = Boolean(options.private);
+  const { ownerId, ownerTypename } = await fetchRepositoryOwnerNodeId();
+  if (dryRun) {
+    console.log(
+      JSON.stringify(
+        {
+          dryRun: true,
+          title,
+          ownerTypename,
+          wouldCreatePublic: !stayPrivate,
+        },
+        null,
+        2,
+      ),
+    );
+    return;
+  }
+  const created = await graphql(
+    `
+    mutation($ownerId: ID!, $title: String!) {
+      createProjectV2(input: { ownerId: $ownerId, title: $title }) {
+        projectV2 {
+          id
+          title
+          public
+          url
+          number
+          closed
+        }
+      }
+    }
+    `,
+    { ownerId, title },
+  );
+  const project = created.createProjectV2.projectV2;
+  if (!project) {
+    throw new Error("createProjectV2 returned no project.");
+  }
+  if (stayPrivate) {
+    console.log(
+      JSON.stringify({ project, visibility: "private" }, null, 2),
+    );
+    return;
+  }
+  const updated = await graphql(
+    `
+    mutation($projectId: ID!, $public: Boolean!) {
+      updateProjectV2(input: { projectId: $projectId, public: $public }) {
+        projectV2 {
+          id
+          title
+          public
+          url
+          number
+          closed
+        }
+      }
+    }
+    `,
+    { projectId: project.id, public: true },
+  );
+  console.log(
+    JSON.stringify(
+      {
+        project: updated.updateProjectV2.projectV2,
+        visibility: "public",
+      },
+      null,
+      2,
+    ),
+  );
 }
 
 async function projectData() {
@@ -973,96 +879,90 @@ async function projectData() {
   );
 }
 
-async function setProjectStatusWorkflow() {
-  const data = await projectData();
-  const project = data.user.projectV2;
-  const statusField = project.fields.nodes.find((field) => field?.name === "Status");
-  if (!statusField) {
-    throw new Error("Project Status field was not found.");
-  }
 
-  const updated = await graphql(
-    `
-    mutation($field:ID!, $name:String!, $options:[ProjectV2SingleSelectFieldOptionInput!]) {
-      updateProjectV2Field(input:{fieldId:$field, name:$name, singleSelectOptions:$options}) {
-        projectV2Field {
-          ... on ProjectV2SingleSelectField {
-            id
-            name
-            options { id name }
-          }
-        }
-      }
-    }
-    `,
-    {
-      field: statusField.id,
-      name: "Status",
-      options: [
-        { name: "Backlog", color: "GRAY", description: "Known work that is not yet ready to start" },
-        { name: "Ready", color: "BLUE", description: "Ready to pick up next" },
-        { name: "In Progress", color: "YELLOW", description: "Actively being worked on" },
-        { name: "Ready for Merge", color: "ORANGE", description: "Implementation is complete and awaiting merge" },
-        { name: "Blocked", color: "RED", description: "Blocked by an external dependency or decision" },
-        { name: "Done", color: "GREEN", description: "Completed work" },
-      ],
-    },
-  );
-
-  const options = Object.fromEntries(
-    updated.updateProjectV2Field.projectV2Field.options.map((option) => [option.name, option.id]),
-  );
-
-  for (const item of project.items.nodes) {
-    const issue = item.content;
-    if (!issue || issue.__typename !== "Issue") {
-      continue;
-    }
-    const target = issue.state === "CLOSED" ? "Done" : "Backlog";
-    await graphql(
-      `
-      mutation($project:ID!, $item:ID!, $field:ID!, $option:String!) {
-        updateProjectV2ItemFieldValue(input:{projectId:$project, itemId:$item, fieldId:$field, value:{singleSelectOptionId:$option}}) {
-          projectV2Item { id }
-        }
-      }
-      `,
-      {
-        project: project.id,
-        item: item.id,
-        field: statusField.id,
-        option: options[target],
-      },
+async function fetchAllNonPullRequestIssues() {
+  const { owner, repo } = repoParts();
+  const out = [];
+  for (let page = 1; page <= 50; page += 1) {
+    const batch = await rest(
+      "GET",
+      `/repos/${owner}/${repo}/issues?state=all&per_page=100&page=${page}`,
     );
+    if (!batch.length) {
+      break;
+    }
+    for (const issue of batch) {
+      if (!issue.pull_request) {
+        out.push(issue);
+      }
+    }
+    if (batch.length < 100) {
+      break;
+    }
   }
-
-  console.log(
-    "Updated Project Status workflow to Backlog / Ready / In Progress / Ready for Merge / Blocked / Done.",
-  );
+  return out;
 }
 
-async function findTask(options) {
-  const taskId = options.task;
-  if (!taskId) {
-    throw new Error("find-task requires --task <Tn.n>.");
+async function listIssues(options) {
+  const raw = String(options.state || "all").toLowerCase();
+  const titlePrefix = options["title-prefix"] || options.titlePrefix;
+  const titleContains = options["title-contains"] || options.titleContains;
+  const limit = Math.max(1, Math.min(2000, Number(options.limit || 500)));
+
+  let issues = await fetchAllNonPullRequestIssues();
+  if (raw === "open") {
+    issues = issues.filter((issue) => issue.state === "open");
+  } else if (raw === "closed") {
+    issues = issues.filter((issue) => issue.state === "closed");
+  } else if (raw !== "all") {
+    throw new Error("list-issues --state must be open, closed, or all.");
+  }
+  if (titlePrefix) {
+    const p = String(titlePrefix);
+    issues = issues.filter((issue) => issue.title.startsWith(p));
+  }
+  if (titleContains) {
+    const c = String(titleContains);
+    issues = issues.filter((issue) => issue.title.includes(c));
   }
 
-  const prefix = `[POC V1] ${taskId} `;
-  const matches = (await allIssues()).filter(
-    (issue) => !issue.pull_request && issue.title.startsWith(prefix),
-  );
-
+  issues = issues.slice(0, limit);
   console.log(
     JSON.stringify(
-      matches.map((issue) => ({
+      issues.map((issue) => ({
         number: issue.number,
         state: issue.state,
         title: issue.title,
+        url: issue.html_url,
+        labels: (issue.labels || []).map((label) => label.name),
       })),
       null,
       2,
     ),
   );
+}
+
+async function deleteIssueByNumber(options) {
+  const number = Number(options.number);
+  if (!Number.isInteger(number) || number <= 0) {
+    throw new Error("delete-issue requires --number <n>.");
+  }
+  const { owner, repo } = repoParts();
+  const issue = await rest("GET", `/repos/${owner}/${repo}/issues/${number}`);
+  if (issue.pull_request) {
+    throw new Error("delete-issue only deletes issues, not pull requests.");
+  }
+  await graphql(
+    `
+    mutation($issue: ID!) {
+      deleteIssue(input: { issueId: $issue }) {
+        clientMutationId
+      }
+    }
+    `,
+    { issue: issue.node_id },
+  );
+  console.log(JSON.stringify({ deleted: true, number }, null, 2));
 }
 
 function issueUrl(issueNumber) {
@@ -1123,15 +1023,11 @@ async function listPrs(options) {
   );
 }
 
-async function listOpenPrs() {
-  await listPrs({ state: "open" });
-}
-
-async function listIssueComments(options) {
+async function listComments(options) {
   const { owner, repo } = repoParts();
   const issueNumber = Number(options.issue);
   if (!Number.isInteger(issueNumber) || issueNumber <= 0) {
-    throw new Error("list-issue-comments requires --issue <n>.");
+    throw new Error("issue-comment --action list requires --issue <n>.");
   }
 
   const comments = await rest(
@@ -1154,11 +1050,11 @@ async function listIssueComments(options) {
   );
 }
 
-async function deleteIssueComment(options) {
+async function deleteComment(options) {
   const { owner, repo } = repoParts();
   const commentId = Number(options["comment-id"] || options.commentId);
   if (!Number.isInteger(commentId) || commentId <= 0) {
-    throw new Error("delete-issue-comment requires --comment-id <n>.");
+    throw new Error("issue-comment --action delete requires --comment-id <n>.");
   }
 
   await rest("DELETE", `/repos/${owner}/${repo}/issues/comments/${commentId}`);
@@ -1171,10 +1067,10 @@ async function commentPr(options) {
   const body = options.body;
 
   if (!Number.isInteger(number) || number <= 0) {
-    throw new Error("comment-pr requires --number <n>.");
+    throw new Error("comment-issue / comment-pr requires --number <n>.");
   }
   if (!body || typeof body !== "string") {
-    throw new Error("comment-pr requires --body <text>.");
+    throw new Error("comment-issue / comment-pr requires --body <text>.");
   }
 
   const comment = await rest(
@@ -1294,10 +1190,10 @@ async function uploadReleaseAsset(options) {
   );
 }
 
-async function listReleaseAssets(options) {
+async function listAssets(options) {
   const tag = options.tag;
   if (!tag || typeof tag !== "string") {
-    throw new Error("list-release-assets requires --tag <tag>.");
+    throw new Error("release-asset --action list requires --tag <tag>.");
   }
 
   const release = await getReleaseByTag(tag);
@@ -1329,10 +1225,10 @@ async function listReleaseAssets(options) {
   );
 }
 
-async function deleteReleaseAssetCommand(options) {
+async function deleteAsset(options) {
   const assetId = Number(options["asset-id"] || options.assetId);
   if (!Number.isInteger(assetId) || assetId <= 0) {
-    throw new Error("delete-release-asset requires --asset-id <n>.");
+    throw new Error("release-asset --action delete requires --asset-id <n>.");
   }
 
   await deleteReleaseAsset(assetId);
@@ -1422,10 +1318,10 @@ async function mergePr(options) {
   );
 }
 
-async function listPrReviewThreads(options) {
+async function listReviewThreads(options) {
   const number = Number(options.number);
   if (!Number.isInteger(number) || number <= 0) {
-    throw new Error("list-pr-review-threads requires --number <n>.");
+    throw new Error("pr-review --action list requires --number <n>.");
   }
 
   const { owner, repo } = repoParts();
@@ -1488,10 +1384,10 @@ async function listPrReviewThreads(options) {
   );
 }
 
-async function resolvePrReviewThread(options) {
+async function resolveThread(options) {
   const threadId = options["thread-id"] || options.threadId;
   if (!threadId) {
-    throw new Error("resolve-pr-review-thread requires --thread-id <id>.");
+    throw new Error("pr-review --action resolve requires --thread-id <id>.");
   }
 
   const data = await graphql(
@@ -1613,9 +1509,21 @@ async function createIssue(options) {
     throw new Error("create-issue requires --title <text>.");
   }
 
+  const bodyFile = options["body-file"] || options.bodyFile;
+  const hasInlineBody = options.body != null && String(options.body).length > 0;
+  if (bodyFile && hasInlineBody) {
+    throw new Error("create-issue: use either --body or --body-file, not both.");
+  }
+  let bodyText = "";
+  if (bodyFile) {
+    bodyText = await readFile(path.resolve(String(bodyFile)), "utf8");
+  } else if (options.body != null) {
+    bodyText = String(options.body);
+  }
+
   const payload = {
     title,
-    body: options.body != null ? String(options.body) : "",
+    body: bodyText,
   };
 
   if (options.labels) {
@@ -1663,9 +1571,19 @@ async function updateIssue(options) {
     throw new Error("update-issue requires --number <n>.");
   }
 
+  const bodyFile = options["body-file"] || options.bodyFile;
+  const hasInlineBody = options.body != null && String(options.body).length > 0;
+  if (bodyFile && hasInlineBody) {
+    throw new Error("update-issue: use either --body or --body-file, not both.");
+  }
+
   const patch = {};
   if (options.title) patch.title = options.title;
-  if (options.body) patch.body = options.body;
+  if (bodyFile) {
+    patch.body = await readFile(path.resolve(String(bodyFile)), "utf8");
+  } else if (options.body) {
+    patch.body = options.body;
+  }
   if (options.state) patch.state = options.state;
   if (options.labels) {
     patch.labels = String(options.labels)
@@ -1675,7 +1593,9 @@ async function updateIssue(options) {
   }
 
   if (Object.keys(patch).length === 0) {
-    throw new Error("update-issue requires at least one of --title, --body, --state, or --labels.");
+    throw new Error(
+      "update-issue requires at least one of --title, --body, --body-file, --state, or --labels.",
+    );
   }
 
   const issue = await rest("PATCH", `/repos/${owner}/${repo}/issues/${number}`, patch);
@@ -1732,133 +1652,6 @@ async function linkPrTask(options) {
       2,
     ),
   );
-}
-
-async function reconcilePocDoc() {
-  const { owner, repo } = repoParts();
-  const markdown = await readFile(
-    "docs/milestones/proof-of-concept-1/poc_v1_task_breakdown.md",
-    "utf8",
-  );
-  const tasks = parsePocTasks(markdown);
-  const milestones = await ensureMilestones();
-  const issues = (await allIssues()).filter(
-    (issue) => !issue.pull_request && issue.title.startsWith("[POC V1] "),
-  );
-  const byTitle = new Map(issues.map((issue) => [issue.title, issue]));
-  const byTaskId = new Map(
-    issues
-      .map((issue) => [taskIdFromTitle(issue.title), issue])
-      .filter(([taskId]) => taskId),
-  );
-
-  const project = (await projectData()).user.projectV2;
-  const statusField = project.fields.nodes.find((field) => field?.name === "Status");
-  const backlogOption = statusField?.options?.find((option) => option.name === "Backlog");
-  const projectItems = new Map(
-    project.items.nodes
-      .filter((item) => item.content?.__typename === "Issue")
-      .map((item) => [item.content.number, item.id]),
-  );
-
-  const created = [];
-  const renamed = [];
-
-  for (const [title, meta] of tasks.entries()) {
-    let issue = byTitle.get(title);
-    if (!issue) {
-      const taskId = meta.taskId;
-      const existingByTaskId = byTaskId.get(taskId);
-      if (existingByTaskId && existingByTaskId.title !== title) {
-        issue = await rest("PATCH", `/repos/${owner}/${repo}/issues/${existingByTaskId.number}`, {
-          title,
-        });
-        renamed.push({
-          number: issue.number,
-          from: existingByTaskId.title,
-          to: title,
-        });
-        byTitle.delete(existingByTaskId.title);
-        byTitle.set(title, issue);
-        byTaskId.set(taskId, issue);
-      }
-    }
-
-    if (!issue) {
-      issue = await rest("POST", `/repos/${owner}/${repo}/issues`, {
-        title,
-        labels: labelsForTask(meta.phase, title),
-        milestone: milestones.get(PHASE_MILESTONE[meta.phase]).number,
-        assignees: [owner],
-      });
-      created.push({ number: issue.number, title: issue.title });
-      byTitle.set(title, issue);
-      byTaskId.set(meta.taskId, issue);
-    } else {
-      await rest("PATCH", `/repos/${owner}/${repo}/issues/${issue.number}`, {
-        labels: labelsForTask(meta.phase, title),
-        milestone: milestones.get(PHASE_MILESTONE[meta.phase]).number,
-      });
-    }
-
-    let itemId = projectItems.get(issue.number);
-    if (!itemId) {
-      itemId = await addIssueToProject(project.id, issue.node_id);
-      projectItems.set(issue.number, itemId);
-    }
-
-    if (statusField && backlogOption && issue.state === "open") {
-      await graphql(
-        `
-        mutation($project:ID!, $item:ID!, $field:ID!, $option:String!) {
-          updateProjectV2ItemFieldValue(input:{projectId:$project, itemId:$item, fieldId:$field, value:{singleSelectOptionId:$option}}) {
-            projectV2Item { id }
-          }
-        }
-        `,
-        {
-          project: project.id,
-          item: itemId,
-          field: statusField.id,
-          option: backlogOption.id,
-        },
-      );
-    }
-  }
-
-  const stale = issues
-    .filter((issue) => !tasks.has(issue.title) && !tasks.has(`[POC V1] ${taskIdFromTitle(issue.title) || ""}`))
-    .map((issue) => ({
-      number: issue.number,
-      title: issue.title,
-    }));
-
-  console.log(
-    JSON.stringify(
-      {
-        created,
-        renamed,
-        stale,
-      },
-      null,
-      2,
-    ),
-  );
-}
-
-async function closeImplemented(options) {
-  const { owner, repo } = repoParts();
-  const commit = options.commit || "062d615";
-  const commitUrl = `https://github.com/${owner}/${repo}/commit/${commit}`;
-
-  for (const [issueNumber, issue] of Object.entries(IMPLEMENTED_ISSUES)) {
-    await rest("POST", `/repos/${owner}/${repo}/issues/${issueNumber}/comments`, {
-      body: `Implemented in [${commit}](${commitUrl}).\n\nWhat landed:\n- ${issue.body}\n\nThis is now present in the current repository state and was shipped as part of the initial published baseline.`,
-    });
-    await rest("PATCH", `/repos/${owner}/${repo}/issues/${issueNumber}`, { state: "closed" });
-  }
-
-  console.log(`Commented on and closed ${Object.keys(IMPLEMENTED_ISSUES).length} implemented issues.`);
 }
 
 async function setIssueStatus(options) {
@@ -1931,198 +1724,11 @@ async function setIssueStatus(options) {
   );
 }
 
-async function completeT0(options) {
-  const { owner, repo } = repoParts();
-  const commit = options.commit;
-  if (!commit) {
-    throw new Error("complete-t0 requires --commit <sha>.");
-  }
-  const commitUrl = `https://github.com/${owner}/${repo}/commit/${commit}`;
-
-  for (const [issueNumber, issue] of Object.entries(T0_IMPLEMENTED_ISSUES)) {
-    await rest("POST", `/repos/${owner}/${repo}/issues/${issueNumber}/comments`, {
-      body:
-        `Implemented in [${commit}](${commitUrl}).\n\nWhat landed:\n- ${issue.comment}\n\nThis completes the corresponding T0 foundation decision work in the repository docs.`,
-    });
-    await rest("PATCH", `/repos/${owner}/${repo}/issues/${issueNumber}`, {
-      state: "closed",
-    });
-  }
-
-  await setIssueStatus({
-    issues: Object.keys(T0_IMPLEMENTED_ISSUES).join(","),
-    status: "Done",
-  });
-
-  console.log(
-    `Commented on, closed, and marked done for ${Object.keys(T0_IMPLEMENTED_ISSUES).length} T0 issues.`,
-  );
-}
-
-async function completeIssue(options) {
-  const { owner, repo } = repoParts();
-  const issueNumber = Number(options.issue);
-  const commit = options.commit;
-  const note = options.note;
-
-  if (!Number.isInteger(issueNumber) || issueNumber <= 0) {
-    throw new Error("complete-issue requires --issue <n>.");
-  }
-  if (!commit) {
-    throw new Error("complete-issue requires --commit <sha>.");
-  }
-  if (!note) {
-    throw new Error("complete-issue requires --note <text>.");
-  }
-
-  const commitUrl = `https://github.com/${owner}/${repo}/commit/${commit}`;
-  await rest("POST", `/repos/${owner}/${repo}/issues/${issueNumber}/comments`, {
-    body:
-      `Implemented in [${commit}](${commitUrl}).\n\nWhat landed:\n- ${note}\n\nThis issue is now complete in the repository state referenced above.`,
-  });
-  await rest("PATCH", `/repos/${owner}/${repo}/issues/${issueNumber}`, {
-    state: "closed",
-  });
-
-  await setIssueStatus({
-    issues: String(issueNumber),
-    status: "Done",
-  });
-
-  console.log(`Commented on, closed, and marked done for issue #${issueNumber}.`);
-}
-
-async function repairT0Numbering() {
-  const { owner, repo } = repoParts();
-  const issues = (await allIssues()).filter(
-    (issue) => !issue.pull_request && issue.title.startsWith("[POC V1] T0."),
-  );
-
-  const removed = issues.find(
-    (issue) => issue.title === "[POC V1] T0.3 Create stable fixtures before adapter implementation",
-  );
-  const renamed = issues.find(
-    (issue) => issue.title === "[POC V1] T0.4 Choose the graph rendering strategy",
-  );
-
-  if (renamed) {
-    await rest("PATCH", `/repos/${owner}/${repo}/issues/${renamed.number}`, {
-      title: "[POC V1] T0.3 Choose the graph rendering strategy",
-    });
-  }
-
-  if (removed) {
-    await graphql(
-      `
-      mutation($issue:ID!) {
-        deleteIssue(input:{issueId:$issue}) {
-          clientMutationId
-        }
-      }
-      `,
-      { issue: removed.node_id },
-    );
-  }
-
-  const refreshed = (await allIssues()).filter(
-    (issue) => !issue.pull_request && issue.title.startsWith("[POC V1] T0."),
-  );
-
-  console.log(
-    JSON.stringify(
-      {
-        deletedIssue: removed ? { number: removed.number, title: removed.title } : null,
-        renamedIssue: renamed
-          ? {
-              number: renamed.number,
-              title: "[POC V1] T0.3 Choose the graph rendering strategy",
-            }
-          : null,
-        currentT0Issues: refreshed.map((issue) => ({
-          number: issue.number,
-          state: issue.state,
-          title: issue.title,
-        })),
-      },
-      null,
-      2,
-    ),
-  );
-}
-
-async function auditPocConsistency() {
-  const markdown = await readFile(
-    "docs/milestones/proof-of-concept-1/poc_v1_task_breakdown.md",
-    "utf8",
-  );
-  const tasks = parsePocTasks(markdown);
-  const docTitles = [...tasks.keys()].sort();
-
-  const suggestedExecutionOrder = parseNumberedSection(markdown, "Suggested Execution Order");
-  const smallestUsefulVerticalSlice = parseNumberedSection(markdown, "Smallest Useful Vertical Slice");
-
-  function numberingIssues(entries, sectionName) {
-    const problems = [];
-    for (let index = 0; index < entries.length; index += 1) {
-      const expected = index + 1;
-      if (entries[index].number !== expected) {
-        problems.push({
-          section: sectionName,
-          expected,
-          found: entries[index].number,
-          taskId: entries[index].taskId,
-        });
-      }
-    }
-    return problems;
-  }
-
-  const githubIssues = (await allIssues()).filter(
-    (issue) => !issue.pull_request && issue.title.startsWith("[POC V1] "),
-  );
-  const githubTitles = githubIssues.map((issue) => issue.title).sort();
-
-  const docMissingOnGithub = docTitles.filter((title) => !githubTitles.includes(title));
-  const githubMissingInDoc = githubTitles.filter((title) => !docTitles.includes(title));
-
-  const duplicateGithubTitles = [...new Set(
-    githubTitles.filter((title, index) => githubTitles.indexOf(title) !== index),
-  )];
-
-  const t0Issues = githubIssues
-    .filter((issue) => issue.title.startsWith("[POC V1] T0."))
-    .map((issue) => ({ number: issue.number, title: issue.title }))
-    .sort((a, b) => a.number - b.number);
-
-  console.log(
-    JSON.stringify(
-      {
-        local: {
-          docTaskCount: docTitles.length,
-          numberingProblems: [
-            ...numberingIssues(suggestedExecutionOrder, "Suggested Execution Order"),
-            ...numberingIssues(smallestUsefulVerticalSlice, "Smallest Useful Vertical Slice"),
-          ],
-        },
-        github: {
-          pocIssueCount: githubIssues.length,
-          t0Issues,
-          docMissingOnGithub,
-          githubMissingInDoc,
-          duplicateGithubTitles,
-        },
-      },
-      null,
-      2,
-    ),
-  );
-}
-
 async function report() {
   const data = await projectData();
   const project = data.user.projectV2;
   const milestones = await allMilestones();
-  const issues = (await allIssues()).filter((issue) => !issue.pull_request && issue.title.startsWith("[POC V1] "));
+  const issues = (await allIssues()).filter((issue) => !issue.pull_request);
   console.log(
     JSON.stringify(
       {
@@ -2135,7 +1741,7 @@ async function report() {
             .filter(Boolean)
             .map((field) => field.name),
         },
-        pocIssueCount: issues.length,
+        issueCount: issues.length,
         milestones: milestones.map((milestone) => ({
           title: milestone.title,
           open: milestone.open_issues,
@@ -2236,6 +1842,58 @@ async function listTasks(options) {
   console.log(JSON.stringify(sorted.slice(0, limit), null, 2));
 }
 
+async function releaseAsset(options) {
+  const action = String(options.action || "").toLowerCase();
+  if (action === "list") {
+    return listAssets(options);
+  }
+  if (action === "delete") {
+    return deleteAsset(options);
+  }
+  throw new Error(
+    "release-asset requires --action list (--tag <tag>) or --action delete (--asset-id <n>).",
+  );
+}
+
+async function issueComment(options) {
+  const action = String(options.action || "").toLowerCase();
+  if (action === "list") {
+    return listComments(options);
+  }
+  if (action === "delete") {
+    return deleteComment(options);
+  }
+  throw new Error(
+    "issue-comment requires --action list (--issue <n>) or --action delete (--comment-id <n>).",
+  );
+}
+
+async function prReview(options) {
+  const action = String(options.action || "").toLowerCase();
+  if (action === "list") {
+    return listReviewThreads(options);
+  }
+  if (action === "resolve") {
+    return resolveThread(options);
+  }
+  throw new Error(
+    "pr-review requires --action list (--number <n>) or --action resolve (--thread-id <id>).",
+  );
+}
+
+async function project(options) {
+  const action = String(options.action || "").toLowerCase();
+  if (action === "link-prs") {
+    return linkPrs(options);
+  }
+  if (action === "close-project") {
+    return closeProject(options);
+  }
+  throw new Error(
+    "project requires --action link-prs [--title-prefix <text>] [--dry-run] or --action close-project [--dry-run].",
+  );
+}
+
 const { command, options } = parseArgs(process.argv.slice(2));
 
 if (!command || command === "help" || command === "--help") {
@@ -2245,38 +1903,28 @@ if (!command || command === "help" || command === "--help") {
 
 const commands = {
   "sync-labels": syncLabels,
-  "assign-poc": () => assignPoc(options),
-  "remap-poc-milestones": remapPocMilestones,
-  "reconcile-poc-doc": reconcilePocDoc,
-  "find-task": () => findTask(options),
+  "list-issues": () => listIssues(options),
   "list-tasks": () => listTasks(options),
-  "list-issue-comments": () => listIssueComments(options),
-  "delete-issue-comment": () => deleteIssueComment(options),
+  "issue-comment": () => issueComment(options),
   "update-issue": () => updateIssue(options),
+  "delete-issue": () => deleteIssueByNumber(options),
   "create-issue": () => createIssue(options),
-  "list-open-prs": listOpenPrs,
+  "create-project": () => createProjectCommand(options),
   "list-prs": () => listPrs(options),
+  "comment-issue": () => commentPr(options),
   "comment-pr": () => commentPr(options),
   "ensure-release": () => ensureRelease(options),
   "upload-release-asset": () => uploadReleaseAsset(options),
-  "list-release-assets": () => listReleaseAssets(options),
-  "delete-release-asset": () => deleteReleaseAssetCommand(options),
+  "release-asset": () => releaseAsset(options),
   "comment-pr-verification": () => commentPrVerification(options),
-  "list-pr-review-threads": () => listPrReviewThreads(options),
-  "resolve-pr-review-thread": () => resolvePrReviewThread(options),
+  "pr-review": () => prReview(options),
   "merge-pr": () => mergePr(options),
   "create-pr": () => createPr(options),
   "update-pr": () => updatePr(options),
   "link-pr-task": () => linkPrTask(options),
-  "link-poc-prs": () => linkPocPrs(options),
-  "close-poc-project": () => closePocProject(options),
-  "set-project-status-workflow": setProjectStatusWorkflow,
+  "project": () => project(options),
+  "set-project-visibility": () => setProjectVisibility(options),
   "set-issue-status": () => setIssueStatus(options),
-  "repair-t0-numbering": repairT0Numbering,
-  "audit-poc-consistency": auditPocConsistency,
-  "complete-issue": () => completeIssue(options),
-  "complete-t0": () => completeT0(options),
-  "close-implemented": () => closeImplemented(options),
   report,
 };
 

--- a/skills/github-admin/scripts/github-admin.mjs
+++ b/skills/github-admin/scripts/github-admin.mjs
@@ -38,7 +38,7 @@ Commands:
   list-issues [--state <open|closed|all>] [--title-prefix <text>] [--title-contains <text>] [--limit <n>]
   list-tasks [--limit <n>]
   issue-comment --action <list|delete> (list: --issue <n>; delete: --comment-id <n>)
-  update-issue --number <n> [--title <title>] [--body <text>] [--body-file <path>] [--state <open|closed>] [--labels <a,b,c>]
+  update-issue --number <n> [--title <title>] [--body <text>] [--body-file <path>] [--state <open|closed>] [--labels <a,b,c>] [--assignees <login,login>]
   create-issue --title <title> [--body <text>] [--body-file <path>] [--labels <a,b,c>] [--milestone <n>] [--assignees <login,login>]
   create-project --title <title> [--private] [--dry-run]   (ProjectV2 owned by GITHUB_REPOSITORY owner; public by default)
   get-issue --number <n>
@@ -956,6 +956,7 @@ async function getIssueCmd(options) {
       {
         number: issue.number,
         title: issue.title,
+        body: issue.body,
         state: issue.state,
         labels: (issue.labels || []).map((l) => l.name),
         milestone: issue.milestone ? { number: issue.milestone.number, title: issue.milestone.title } : null,
@@ -1652,10 +1653,16 @@ async function updateIssue(options) {
       .map((label) => label.trim())
       .filter(Boolean);
   }
+  if (options.assignees) {
+    patch.assignees = String(options.assignees)
+      .split(",")
+      .map((assignee) => assignee.trim())
+      .filter(Boolean);
+  }
 
   if (Object.keys(patch).length === 0) {
     throw new Error(
-      "update-issue requires at least one of --title, --body, --body-file, --state, or --labels.",
+      "update-issue requires at least one of --title, --body, --body-file, --state, --labels, or --assignees.",
     );
   }
 

--- a/skills/github-admin/scripts/github-admin.mjs
+++ b/skills/github-admin/scripts/github-admin.mjs
@@ -4,6 +4,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 
 const DEFAULT_REPO = "fcarucci/daneel";
 const PROJECT_NUMBER = 1;
@@ -38,7 +39,7 @@ Commands:
   list-issues [--state <open|closed|all>] [--title-prefix <text>] [--title-contains <text>] [--limit <n>]
   list-tasks [--limit <n>]
   issue-comment --action <list|delete> (list: --issue <n>; delete: --comment-id <n>)
-  update-issue --number <n> [--title <title>] [--body <text>] [--body-file <path>] [--state <open|closed>] [--labels <a,b,c>] [--assignees <login,login>]
+  update-issue --number <n> [--title <title>] [--body <text>] [--body-file <path>] [--state <open|closed>] [--labels <a,b,c>] [--assignees <login,login>] [--milestone <n>]
   create-issue --title <title> [--body <text>] [--body-file <path>] [--labels <a,b,c>] [--milestone <n>] [--assignees <login,login>]
   create-project --title <title> [--private] [--dry-run]   (ProjectV2 owned by GITHUB_REPOSITORY owner; public by default)
   get-issue --number <n>
@@ -152,6 +153,13 @@ function parseArgs(argv) {
     }
   }
   return { command, options };
+}
+
+function parseCsvList(value) {
+  return String(value || "")
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter(Boolean);
 }
 
 async function rest(method, path, body) {
@@ -905,6 +913,10 @@ async function fetchAllNonPullRequestIssues() {
   return out;
 }
 
+function normalizeTitleFilter(value) {
+  return String(value).toLowerCase();
+}
+
 async function listIssues(options) {
   const raw = String(options.state || "all").toLowerCase();
   const titlePrefix = options["title-prefix"] || options.titlePrefix;
@@ -920,12 +932,12 @@ async function listIssues(options) {
     throw new Error("list-issues --state must be open, closed, or all.");
   }
   if (titlePrefix) {
-    const p = String(titlePrefix);
-    issues = issues.filter((issue) => issue.title.startsWith(p));
+    const normalizedPrefix = normalizeTitleFilter(titlePrefix);
+    issues = issues.filter((issue) => normalizeTitleFilter(issue.title).startsWith(normalizedPrefix));
   }
   if (titleContains) {
-    const c = String(titleContains);
-    issues = issues.filter((issue) => issue.title.includes(c));
+    const normalizedContains = normalizeTitleFilter(titleContains);
+    issues = issues.filter((issue) => normalizeTitleFilter(issue.title).includes(normalizedContains));
   }
 
   issues = issues.slice(0, limit);
@@ -1002,10 +1014,7 @@ async function labelIssue(options) {
   const action = String(options.action || "").toLowerCase();
 
   if (action === "add") {
-    const labels = String(options.labels || "")
-      .split(",")
-      .map((l) => l.trim())
-      .filter(Boolean);
+    const labels = parseCsvList(options.labels);
     if (labels.length === 0) {
       throw new Error("label-issue --action add requires --labels <a,b,...>.");
     }
@@ -1589,10 +1598,7 @@ async function createIssue(options) {
   };
 
   if (options.labels) {
-    payload.labels = String(options.labels)
-      .split(",")
-      .map((label) => label.trim())
-      .filter(Boolean);
+    payload.labels = parseCsvList(options.labels);
   }
 
   if (options.milestone) {
@@ -1604,10 +1610,7 @@ async function createIssue(options) {
   }
 
   if (options.assignees) {
-    payload.assignees = String(options.assignees)
-      .split(",")
-      .map((login) => login.trim())
-      .filter(Boolean);
+    payload.assignees = parseCsvList(options.assignees);
   }
 
   const issue = await rest("POST", `/repos/${owner}/${repo}/issues`, payload);
@@ -1648,21 +1651,22 @@ async function updateIssue(options) {
   }
   if (options.state) patch.state = options.state;
   if (options.labels) {
-    patch.labels = String(options.labels)
-      .split(",")
-      .map((label) => label.trim())
-      .filter(Boolean);
+    patch.labels = parseCsvList(options.labels);
   }
   if (options.assignees) {
-    patch.assignees = String(options.assignees)
-      .split(",")
-      .map((assignee) => assignee.trim())
-      .filter(Boolean);
+    patch.assignees = parseCsvList(options.assignees);
+  }
+  if (options.milestone !== undefined) {
+    const milestone = Number(options.milestone);
+    if (!Number.isInteger(milestone) || milestone <= 0) {
+      throw new Error("update-issue --milestone must be a positive integer (repo milestone number).");
+    }
+    patch.milestone = milestone;
   }
 
   if (Object.keys(patch).length === 0) {
     throw new Error(
-      "update-issue requires at least one of --title, --body, --body-file, --state, --labels, or --assignees.",
+      "update-issue requires at least one of --title, --body, --body-file, --state, --labels, --assignees, or --milestone.",
     );
   }
 
@@ -1682,7 +1686,6 @@ async function updateIssue(options) {
 }
 
 async function linkPrTask(options) {
-  const { owner, repo } = repoParts();
   const issueNumber = Number(options.issue);
   const pullNumber = Number(options.pr);
   if (!Number.isInteger(issueNumber) || issueNumber <= 0) {
@@ -1692,16 +1695,11 @@ async function linkPrTask(options) {
     throw new Error("link-pr-task requires --pr <n>.");
   }
 
-  const pull = await getPullRequest(pullNumber);
-  const closingLine = options.close ? `\n\nCloses #${issueNumber}` : "";
-  const nextBody = `${pull.body || ""}${closingLine}`.trim();
-
-  await rest("PATCH", `/repos/${owner}/${repo}/pulls/${pullNumber}`, {
-    body: nextBody,
-  });
-  await rest("POST", `/repos/${owner}/${repo}/issues/${issueNumber}/comments`, {
-    body: `Linked pull request: [#${pullNumber}](${pullUrl(pullNumber)})`,
-  });
+  const { patchedBody, postedComment } = await ensureIssueLinkedToPull(
+    issueNumber,
+    pullNumber,
+    false,
+  );
 
   console.log(
     JSON.stringify(
@@ -1715,6 +1713,8 @@ async function linkPrTask(options) {
           url: pullUrl(pullNumber),
         },
         closesIssue: Boolean(options.close),
+        patchedBody,
+        postedComment,
       },
       null,
       2,
@@ -1962,45 +1962,53 @@ async function project(options) {
   );
 }
 
-const { command, options } = parseArgs(process.argv.slice(2));
+async function main(argv = process.argv.slice(2)) {
+  const { command, options } = parseArgs(argv);
 
-if (!command || command === "help" || command === "--help") {
-  usage();
-  process.exit(command ? 0 : 1);
+  if (!command || command === "help" || command === "--help") {
+    usage();
+    process.exit(command ? 0 : 1);
+  }
+
+  const commands = {
+    "sync-labels": syncLabels,
+    "list-issues": () => listIssues(options),
+    "list-tasks": () => listTasks(options),
+    "issue-comment": () => issueComment(options),
+    "update-issue": () => updateIssue(options),
+    "get-issue": () => getIssueCmd(options),
+    "delete-issue": () => deleteIssueByNumber(options),
+    "label-issue": () => labelIssue(options),
+    "create-issue": () => createIssue(options),
+    "create-project": () => createProjectCommand(options),
+    "list-prs": () => listPrs(options),
+    "comment-issue": () => commentPr(options),
+    "comment-pr": () => commentPr(options),
+    "ensure-release": () => ensureRelease(options),
+    "upload-release-asset": () => uploadReleaseAsset(options),
+    "release-asset": () => releaseAsset(options),
+    "comment-pr-verification": () => commentPrVerification(options),
+    "pr-review": () => prReview(options),
+    "merge-pr": () => mergePr(options),
+    "create-pr": () => createPr(options),
+    "update-pr": () => updatePr(options),
+    "link-pr-task": () => linkPrTask(options),
+    "project": () => project(options),
+    "set-project-visibility": () => setProjectVisibility(options),
+    "set-issue-status": () => setIssueStatus(options),
+    report,
+  };
+
+  if (!commands[command]) {
+    usage();
+    throw new Error(`Unknown command: ${command}`);
+  }
+
+  await commands[command]();
 }
 
-const commands = {
-  "sync-labels": syncLabels,
-  "list-issues": () => listIssues(options),
-  "list-tasks": () => listTasks(options),
-  "issue-comment": () => issueComment(options),
-  "update-issue": () => updateIssue(options),
-  "get-issue": () => getIssueCmd(options),
-  "delete-issue": () => deleteIssueByNumber(options),
-  "label-issue": () => labelIssue(options),
-  "create-issue": () => createIssue(options),
-  "create-project": () => createProjectCommand(options),
-  "list-prs": () => listPrs(options),
-  "comment-issue": () => commentPr(options),
-  "comment-pr": () => commentPr(options),
-  "ensure-release": () => ensureRelease(options),
-  "upload-release-asset": () => uploadReleaseAsset(options),
-  "release-asset": () => releaseAsset(options),
-  "comment-pr-verification": () => commentPrVerification(options),
-  "pr-review": () => prReview(options),
-  "merge-pr": () => mergePr(options),
-  "create-pr": () => createPr(options),
-  "update-pr": () => updatePr(options),
-  "link-pr-task": () => linkPrTask(options),
-  "project": () => project(options),
-  "set-project-visibility": () => setProjectVisibility(options),
-  "set-issue-status": () => setIssueStatus(options),
-  report,
-};
-
-if (!commands[command]) {
-  usage();
-  throw new Error(`Unknown command: ${command}`);
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  await main();
 }
 
-await commands[command]();
+export { linkPrTask, listIssues, main, parseArgs, updateIssue };

--- a/skills/github-admin/scripts/github-admin.mjs
+++ b/skills/github-admin/scripts/github-admin.mjs
@@ -42,6 +42,7 @@ Commands:
   create-issue --title <title> [--body <text>] [--body-file <path>] [--labels <a,b,c>] [--milestone <n>] [--assignees <login,login>]
   create-project --title <title> [--private] [--dry-run]   (ProjectV2 owned by GITHUB_REPOSITORY owner; public by default)
   delete-issue --number <n>
+  label-issue --action <add|remove> (add: --number <n> --labels <a,b>; remove: --number <n> --label <name>)
   list-prs [--state <open|closed|all>]   (default: open)
   comment-issue --number <n> --body <text>
   comment-pr --number <n> --body <text>   (alias: same as comment-issue; works for PRs)
@@ -963,6 +964,40 @@ async function deleteIssueByNumber(options) {
     { issue: issue.node_id },
   );
   console.log(JSON.stringify({ deleted: true, number }, null, 2));
+}
+
+async function labelIssue(options) {
+  const { owner, repo } = repoParts();
+  const number = Number(options.number);
+  if (!Number.isInteger(number) || number <= 0) {
+    throw new Error("label-issue requires --number <n>.");
+  }
+  const action = String(options.action || "").toLowerCase();
+
+  if (action === "add") {
+    const labels = String(options.labels || "")
+      .split(",")
+      .map((l) => l.trim())
+      .filter(Boolean);
+    if (labels.length === 0) {
+      throw new Error("label-issue --action add requires --labels <a,b,...>.");
+    }
+    const issue = await rest("POST", `/repos/${owner}/${repo}/issues/${number}/labels`, { labels });
+    console.log(JSON.stringify({ number, labels: issue.map((l) => l.name) }, null, 2));
+    return;
+  }
+
+  if (action === "remove") {
+    const label = String(options.label || "").trim();
+    if (!label) {
+      throw new Error("label-issue --action remove requires --label <name>.");
+    }
+    await rest("DELETE", `/repos/${owner}/${repo}/issues/${number}/labels/${encodeURIComponent(label)}`);
+    console.log(JSON.stringify({ number, removed: label }, null, 2));
+    return;
+  }
+
+  throw new Error("label-issue requires --action add (--labels <a,b>) or --action remove (--label <name>).");
 }
 
 function issueUrl(issueNumber) {
@@ -1908,6 +1943,7 @@ const commands = {
   "issue-comment": () => issueComment(options),
   "update-issue": () => updateIssue(options),
   "delete-issue": () => deleteIssueByNumber(options),
+  "label-issue": () => labelIssue(options),
   "create-issue": () => createIssue(options),
   "create-project": () => createProjectCommand(options),
   "list-prs": () => listPrs(options),

--- a/skills/github-admin/scripts/github-admin.mjs
+++ b/skills/github-admin/scripts/github-admin.mjs
@@ -41,6 +41,7 @@ Commands:
   update-issue --number <n> [--title <title>] [--body <text>] [--body-file <path>] [--state <open|closed>] [--labels <a,b,c>]
   create-issue --title <title> [--body <text>] [--body-file <path>] [--labels <a,b,c>] [--milestone <n>] [--assignees <login,login>]
   create-project --title <title> [--private] [--dry-run]   (ProjectV2 owned by GITHUB_REPOSITORY owner; public by default)
+  get-issue --number <n>
   delete-issue --number <n>
   label-issue --action <add|remove> (add: --number <n> --labels <a,b>; remove: --number <n> --label <name>)
   list-prs [--state <open|closed|all>]   (default: open)
@@ -937,6 +938,31 @@ async function listIssues(options) {
         url: issue.html_url,
         labels: (issue.labels || []).map((label) => label.name),
       })),
+      null,
+      2,
+    ),
+  );
+}
+
+async function getIssueCmd(options) {
+  const number = Number(options.number);
+  if (!Number.isInteger(number) || number <= 0) {
+    throw new Error("get-issue requires --number <n>.");
+  }
+  const { owner, repo } = repoParts();
+  const issue = await rest("GET", `/repos/${owner}/${repo}/issues/${number}`);
+  console.log(
+    JSON.stringify(
+      {
+        number: issue.number,
+        title: issue.title,
+        state: issue.state,
+        labels: (issue.labels || []).map((l) => l.name),
+        milestone: issue.milestone ? { number: issue.milestone.number, title: issue.milestone.title } : null,
+        assignees: (issue.assignees || []).map((a) => a.login),
+        url: issue.html_url,
+        isPullRequest: Boolean(issue.pull_request),
+      },
       null,
       2,
     ),
@@ -1942,6 +1968,7 @@ const commands = {
   "list-tasks": () => listTasks(options),
   "issue-comment": () => issueComment(options),
   "update-issue": () => updateIssue(options),
+  "get-issue": () => getIssueCmd(options),
   "delete-issue": () => deleteIssueByNumber(options),
   "label-issue": () => labelIssue(options),
   "create-issue": () => createIssue(options),

--- a/skills/github-admin/scripts/github-admin.test.mjs
+++ b/skills/github-admin/scripts/github-admin.test.mjs
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { linkPrTask, listIssues, updateIssue } from "./github-admin.mjs";
+
+function jsonResponse(payload) {
+  return {
+    ok: true,
+    status: 200,
+    async text() {
+      return JSON.stringify(payload);
+    },
+    async json() {
+      return payload;
+    },
+  };
+}
+
+async function withMockedFetch(handler, fn) {
+  const originalFetch = global.fetch;
+  const originalLog = console.log;
+  const calls = [];
+  const logs = [];
+
+  process.env.GITHUB_TOKEN = "test-token";
+  process.env.GITHUB_REPOSITORY = "acme/widgets";
+
+  global.fetch = async (url, options = {}) => {
+    const method = options.method || "GET";
+    const rawBody = options.body;
+    const body = rawBody ? JSON.parse(rawBody) : undefined;
+    calls.push({ url, method, body });
+    return handler({ url, method, body, calls });
+  };
+  console.log = (line) => {
+    logs.push(line);
+  };
+
+  try {
+    await fn({ calls, logs });
+  } finally {
+    global.fetch = originalFetch;
+    console.log = originalLog;
+    delete process.env.GITHUB_TOKEN;
+    delete process.env.GITHUB_REPOSITORY;
+  }
+}
+
+test("updateIssue supports milestone updates", async () => {
+  await withMockedFetch(
+    ({ url, method, body }) => {
+      assert.equal(url, "https://api.github.com/repos/acme/widgets/issues/17");
+      assert.equal(method, "PATCH");
+      assert.deepEqual(body, { milestone: 5 });
+      return jsonResponse({
+        number: 17,
+        state: "open",
+        title: "Example",
+        html_url: "https://github.com/acme/widgets/issues/17",
+      });
+    },
+    async ({ logs }) => {
+      await updateIssue({ number: "17", milestone: "5" });
+      const output = JSON.parse(logs[0]);
+      assert.equal(output.number, 17);
+    },
+  );
+});
+
+test("linkPrTask skips duplicate patch and comment when already linked", async () => {
+  await withMockedFetch(
+    ({ url, method }) => {
+      if (url === "https://api.github.com/repos/acme/widgets/pulls/9") {
+        assert.equal(method, "GET");
+        return jsonResponse({
+          number: 9,
+          body: "Summary\n\nCloses #7",
+          html_url: "https://github.com/acme/widgets/pull/9",
+        });
+      }
+      if (url === "https://api.github.com/repos/acme/widgets/issues/7/comments?per_page=100") {
+        assert.equal(method, "GET");
+        return jsonResponse([
+          {
+            id: 11,
+            body: "Linked pull request: [#9](https://github.com/acme/widgets/pull/9)",
+          },
+        ]);
+      }
+      assert.fail(`Unexpected request: ${method} ${url}`);
+    },
+    async ({ calls, logs }) => {
+      await linkPrTask({ pr: "9", issue: "7", close: true });
+      assert.equal(calls.length, 2);
+      const output = JSON.parse(logs[0]);
+      assert.equal(output.patchedBody, false);
+      assert.equal(output.postedComment, false);
+    },
+  );
+});
+
+test("listIssues title filters are case-insensitive", async () => {
+  await withMockedFetch(
+    ({ url, method }) => {
+      assert.equal(
+        url,
+        "https://api.github.com/repos/acme/widgets/issues?state=all&per_page=100&page=1",
+      );
+      assert.equal(method, "GET");
+      return jsonResponse([
+        { number: 1, state: "open", title: "[T2.7] Improve Sync", html_url: "x" },
+      ]);
+    },
+    async ({ logs }) => {
+      await listIssues({ state: "open", "title-contains": "improve sync" });
+      const output = JSON.parse(logs[0]);
+      assert.equal(output.length, 1);
+      assert.equal(output[0].number, 1);
+    },
+  );
+});

--- a/skills/project-management/SKILL.md
+++ b/skills/project-management/SKILL.md
@@ -23,9 +23,8 @@ The calling workflow provides the issue number and the event name.
 
 ## Prerequisites
 
-Read [`skills/github-admin/SKILL.md`](../github-admin/SKILL.md) (or its
-`.cursor` symlink) before running any commands.  Auth, repo defaults, and
-approval-prefix guidance live there.
+Read [`skills/github-admin/SKILL.md`](../github-admin/SKILL.md) before running any commands.
+Auth, repo defaults, and approval-prefix guidance live there.
 
 ## Step-by-step for each event
 

--- a/skills/project-management/SKILL.md
+++ b/skills/project-management/SKILL.md
@@ -147,24 +147,90 @@ node skills/github-admin/scripts/github-admin.mjs \
 
 ### `ready-for-merge` — PR is open, work is complete
 
+Run these steps in order. Each step is idempotent — re-running is safe.
+
+#### A. Fetch issue metadata
+
 ```bash
-# 1. Set project status
+node skills/github-admin/scripts/github-admin.mjs \
+  get-issue --number <ISSUE_NUMBER>
+```
+
+Capture the output: `labels`, `milestone.number`, `assignees`. You will
+need these values in the steps below.
+
+#### B. Set project board status
+
+```bash
 node skills/github-admin/scripts/github-admin.mjs \
   set-issue-status --issues <ISSUE_NUMBER> --status "Ready for Merge"
+```
 
-# 2. Remove blocked label if previously set (safe to fail)
+#### C. Remove `blocked` label if present (safe to fail)
+
+```bash
 node skills/github-admin/scripts/github-admin.mjs \
   label-issue --action remove --number <ISSUE_NUMBER> --label blocked \
   2>/dev/null || true
+```
 
-# 3. Link PR to issue (adds closing keyword + comment)
+#### D. Link PR to issue
+
+Adds `Closes #<ISSUE_NUMBER>` to the PR body and posts a linked-PR comment
+on the issue so the connection is visible from both sides:
+
+```bash
 node skills/github-admin/scripts/github-admin.mjs \
   link-pr-task --pr <PR_NUMBER> --issue <ISSUE_NUMBER> --close
+```
 
-# 4. Post implementation summary as an issue comment
+#### E. Mirror issue labels onto the PR
+
+GitHub does not automatically copy labels from an issue to its PR.
+Apply all labels from the issue to the PR so both show the same
+classification (component, priority, type):
+
+```bash
+node skills/github-admin/scripts/github-admin.mjs \
+  label-issue --action add --number <PR_NUMBER> \
+  --labels <COMMA_SEPARATED_ISSUE_LABELS>
+```
+
+Skip this step if the issue has no labels.
+
+#### F. Mirror issue milestone onto the PR
+
+GitHub treats PRs as issues for milestone purposes. Copy the milestone:
+
+```bash
+node skills/github-admin/scripts/github-admin.mjs \
+  update-issue --number <PR_NUMBER> --milestone <ISSUE_MILESTONE_NUMBER>
+```
+
+Skip this step if the issue has no milestone.
+
+#### G. Verify PR title references the task
+
+Read the PR title. If it does not reference the task ID or the issue
+number, post a warning comment on the PR:
+
+```bash
+node skills/github-admin/scripts/github-admin.mjs \
+  comment-issue --number <PR_NUMBER> \
+  --body "⚠️ PR title does not reference the task or issue. Consider updating it to make the connection explicit."
+```
+
+Only post this warning if the title is genuinely missing the reference.
+
+#### H. Post implementation summary on the issue
+
+```bash
 node skills/github-admin/scripts/github-admin.mjs \
   comment-issue --number <ISSUE_NUMBER> --body "<SUMMARY>"
 ```
+
+The summary should cover: what changed, how it was tested, any known
+limitations or follow-up items.
 
 ### `done` — PR merged or task closed manually
 

--- a/skills/project-management/SKILL.md
+++ b/skills/project-management/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: project-management
+description: >
+  Synchronises GitHub Project status and issue comments whenever a task or issue
+  transitions lifecycle state (started, blocked, ready-for-merge, done).
+  Use when the workflow reaches a status-transition checkpoint: starting a branch,
+  opening a PR, merging, or blocking work.  Depends on the github-admin skill.
+---
+
+# Project Management
+
+## When to invoke
+
+Use this skill **as a subagent** at each lifecycle checkpoint listed below.
+The calling workflow provides the issue number and the event name.
+
+| Checkpoint in workflow | Event |
+|------------------------|-------|
+| Branch created, work begins | `started` |
+| Work is blocked by an external dependency | `blocked` |
+| PR opened and all verification passes | `ready-for-merge` |
+| PR merged or issue closed | `done` |
+
+## Prerequisites
+
+Read [`skills/github-admin/SKILL.md`](../github-admin/SKILL.md) (or its
+`.cursor` symlink) before running any commands.  Auth, repo defaults, and
+approval-prefix guidance live there.
+
+## Step-by-step for each event
+
+### `started` — work begins
+
+```bash
+# 1. Set project board status
+node skills/github-admin/scripts/github-admin.mjs \
+  set-issue-status --issues <ISSUE_NUMBER> --status "In Progress"
+
+# 2. Comment on the issue with the branch being worked on
+node skills/github-admin/scripts/github-admin.mjs \
+  comment-issue --number <ISSUE_NUMBER> \
+  --body "Work started on branch \`<BRANCH_NAME>\`."
+```
+
+### `blocked` — work cannot proceed
+
+```bash
+# 1. Set project board status
+node skills/github-admin/scripts/github-admin.mjs \
+  set-issue-status --issues <ISSUE_NUMBER> --status "Blocked"
+
+# 2. Comment with the blocking reason
+node skills/github-admin/scripts/github-admin.mjs \
+  comment-issue --number <ISSUE_NUMBER> \
+  --body "Blocked: <REASON>"
+```
+
+### `ready-for-merge` — PR is open, work is complete
+
+```bash
+# 1. Set project board status
+node skills/github-admin/scripts/github-admin.mjs \
+  set-issue-status --issues <ISSUE_NUMBER> --status "Ready for Merge"
+
+# 2. Link PR to issue (adds closing keyword + issue comment)
+node skills/github-admin/scripts/github-admin.mjs \
+  link-pr-task --pr <PR_NUMBER> --issue <ISSUE_NUMBER> --close
+```
+
+### `done` — PR merged or issue closed manually
+
+```bash
+# 1. Set project board status
+node skills/github-admin/scripts/github-admin.mjs \
+  set-issue-status --issues <ISSUE_NUMBER> --status "Done"
+
+# 2. Close the issue if not already closed by the merge
+node skills/github-admin/scripts/github-admin.mjs \
+  update-issue --number <ISSUE_NUMBER> --state closed
+```
+
+## Lookup: find the issue number
+
+If the issue number is not already known, use:
+
+```bash
+node skills/github-admin/scripts/github-admin.mjs \
+  list-issues --title-contains "<task-id-or-keyword>" --state open
+```
+
+## Error handling
+
+- If `set-issue-status` throws "item not found in project", the issue has not
+  been added to the configured Project Board.  Add it via the GitHub UI or skip
+  the status step and only post the comment.
+- If the issue is already in the target status, the command is idempotent and
+  exits cleanly — no action needed.
+- Never skip the comment step; it provides a human-readable audit trail even
+  when the board status is already correct.

--- a/skills/project-management/SKILL.md
+++ b/skills/project-management/SKILL.md
@@ -36,7 +36,12 @@ approval-prefix guidance live there.
 node skills/github-admin/scripts/github-admin.mjs \
   set-issue-status --issues <ISSUE_NUMBER> --status "In Progress"
 
-# 2. Comment on the issue with the branch being worked on
+# 2. Remove blocked label if it was previously set
+node skills/github-admin/scripts/github-admin.mjs \
+  label-issue --action remove --number <ISSUE_NUMBER> --label blocked \
+  2>/dev/null || true
+
+# 3. Comment with the branch being worked on
 node skills/github-admin/scripts/github-admin.mjs \
   comment-issue --number <ISSUE_NUMBER> \
   --body "Work started on branch \`<BRANCH_NAME>\`."
@@ -49,7 +54,11 @@ node skills/github-admin/scripts/github-admin.mjs \
 node skills/github-admin/scripts/github-admin.mjs \
   set-issue-status --issues <ISSUE_NUMBER> --status "Blocked"
 
-# 2. Comment with the blocking reason
+# 2. Apply the blocked label
+node skills/github-admin/scripts/github-admin.mjs \
+  label-issue --action add --number <ISSUE_NUMBER> --labels blocked
+
+# 3. Comment with the blocking reason
 node skills/github-admin/scripts/github-admin.mjs \
   comment-issue --number <ISSUE_NUMBER> \
   --body "Blocked: <REASON>"
@@ -62,7 +71,12 @@ node skills/github-admin/scripts/github-admin.mjs \
 node skills/github-admin/scripts/github-admin.mjs \
   set-issue-status --issues <ISSUE_NUMBER> --status "Ready for Merge"
 
-# 2. Link PR to issue (adds closing keyword + issue comment)
+# 2. Remove blocked label if it was previously set
+node skills/github-admin/scripts/github-admin.mjs \
+  label-issue --action remove --number <ISSUE_NUMBER> --label blocked \
+  2>/dev/null || true
+
+# 3. Link PR to issue (adds closing keyword + issue comment)
 node skills/github-admin/scripts/github-admin.mjs \
   link-pr-task --pr <PR_NUMBER> --issue <ISSUE_NUMBER> --close
 ```

--- a/skills/project-management/SKILL.md
+++ b/skills/project-management/SKILL.md
@@ -1,41 +1,58 @@
 ---
 name: project-management
 description: >
-  Synchronises GitHub Project status and issue comments whenever a task or issue
-  transitions lifecycle state (started, blocked, ready-for-merge, done).
-  Use when the workflow reaches a status-transition checkpoint: starting a branch,
-  opening a PR, merging, or blocking work.  Depends on the github-admin skill.
+  Updates project tracking whenever a task transitions lifecycle state
+  (started, blocked, ready-for-merge, done). Receives task context from the
+  calling workflow, resolves the associated work item if one exists, then
+  updates its status and posts a comment. Exits gracefully when no work item
+  is found. Depends on the github-admin skill for GitHub operations.
 ---
 
 # Project Management
 
 ## When to invoke
 
-Use this skill **as a subagent** at each lifecycle checkpoint listed below.
-The calling workflow provides the issue number and the event name.
+Use this skill **as a subagent** at each lifecycle checkpoint.
+The calling workflow passes task context and an event name — this skill
+resolves the work item and acts on it.
 
 | Checkpoint in workflow | Event |
 |------------------------|-------|
 | Branch created, work begins | `started` |
 | Work is blocked by an external dependency | `blocked` |
 | PR opened and all verification passes | `ready-for-merge` |
-| PR merged or issue closed | `done` |
+| PR merged or task closed | `done` |
 
-## Prerequisites
+## Step 1: Resolve task to a work item
 
-Read [`skills/github-admin/SKILL.md`](../github-admin/SKILL.md) before running any commands.
-Auth, repo defaults, and approval-prefix guidance live there.
+Before doing anything else, determine the issue number from the context provided.
 
-## Step-by-step for each event
+**If an issue number was given directly** — use it.
+
+**Otherwise, search by task ID or name:**
+
+```bash
+node skills/github-admin/scripts/github-admin.mjs \
+  list-issues --title-contains "<TASK_ID_OR_NAME>" --state open
+```
+
+Pick the issue whose title best matches the task. If no match is found,
+**exit gracefully** — log "No work item found for task <TASK>; skipping
+project management." and stop. Do not error.
+
+Read [`skills/github-admin/SKILL.md`](../github-admin/SKILL.md) for auth
+and configuration before running any commands.
+
+## Step 2: Act on the event
 
 ### `started` — work begins
 
 ```bash
-# 1. Set project board status
+# 1. Set project status
 node skills/github-admin/scripts/github-admin.mjs \
   set-issue-status --issues <ISSUE_NUMBER> --status "In Progress"
 
-# 2. Remove blocked label if it was previously set
+# 2. Remove blocked label if previously set (safe to fail)
 node skills/github-admin/scripts/github-admin.mjs \
   label-issue --action remove --number <ISSUE_NUMBER> --label blocked \
   2>/dev/null || true
@@ -49,7 +66,7 @@ node skills/github-admin/scripts/github-admin.mjs \
 ### `blocked` — work cannot proceed
 
 ```bash
-# 1. Set project board status
+# 1. Set project status
 node skills/github-admin/scripts/github-admin.mjs \
   set-issue-status --issues <ISSUE_NUMBER> --status "Blocked"
 
@@ -66,24 +83,28 @@ node skills/github-admin/scripts/github-admin.mjs \
 ### `ready-for-merge` — PR is open, work is complete
 
 ```bash
-# 1. Set project board status
+# 1. Set project status
 node skills/github-admin/scripts/github-admin.mjs \
   set-issue-status --issues <ISSUE_NUMBER> --status "Ready for Merge"
 
-# 2. Remove blocked label if it was previously set
+# 2. Remove blocked label if previously set (safe to fail)
 node skills/github-admin/scripts/github-admin.mjs \
   label-issue --action remove --number <ISSUE_NUMBER> --label blocked \
   2>/dev/null || true
 
-# 3. Link PR to issue (adds closing keyword + issue comment)
+# 3. Link PR to issue (adds closing keyword + comment)
 node skills/github-admin/scripts/github-admin.mjs \
   link-pr-task --pr <PR_NUMBER> --issue <ISSUE_NUMBER> --close
+
+# 4. Post implementation summary as an issue comment
+node skills/github-admin/scripts/github-admin.mjs \
+  comment-issue --number <ISSUE_NUMBER> --body "<SUMMARY>"
 ```
 
-### `done` — PR merged or issue closed manually
+### `done` — PR merged or task closed manually
 
 ```bash
-# 1. Set project board status
+# 1. Set project status
 node skills/github-admin/scripts/github-admin.mjs \
   set-issue-status --issues <ISSUE_NUMBER> --status "Done"
 
@@ -92,21 +113,10 @@ node skills/github-admin/scripts/github-admin.mjs \
   update-issue --number <ISSUE_NUMBER> --state closed
 ```
 
-## Lookup: find the issue number
-
-If the issue number is not already known, use:
-
-```bash
-node skills/github-admin/scripts/github-admin.mjs \
-  list-issues --title-contains "<task-id-or-keyword>" --state open
-```
-
 ## Error handling
 
-- If `set-issue-status` throws "item not found in project", the issue has not
-  been added to the configured Project Board.  Add it via the GitHub UI or skip
-  the status step and only post the comment.
-- If the issue is already in the target status, the command is idempotent and
-  exits cleanly — no action needed.
-- Never skip the comment step; it provides a human-readable audit trail even
-  when the board status is already correct.
+- **No work item found** — exit gracefully with a log message; never error.
+- **Item not in project board** — skip `set-issue-status`; still post the comment.
+- **Status already correct** — `set-issue-status` is idempotent; no action needed.
+- **Label not present on remove** — suppress the error (`2>/dev/null || true`).
+- **Never skip the comment step** — it provides an audit trail even when board status is unchanged.

--- a/skills/project-management/SKILL.md
+++ b/skills/project-management/SKILL.md
@@ -13,8 +13,9 @@ description: >
 ## When to invoke
 
 Use this skill **as a subagent** at each lifecycle checkpoint.
-The calling workflow passes task context and an event name — this skill
-resolves the work item and acts on it.
+The calling workflow passes task context and an event name. This skill
+resolves the work item, performs the matching project-management update,
+and leaves an audit trail on GitHub.
 
 | Checkpoint in workflow | Event |
 |------------------------|-------|
@@ -23,63 +24,97 @@ resolves the work item and acts on it.
 | PR opened and all verification passes | `ready-for-merge` |
 | PR merged or task closed | `done` |
 
+## Operating rules
+
+Read [`skills/github-admin/SKILL.md`](../github-admin/SKILL.md) before running
+any commands.
+
+Non-negotiable rules:
+
+- **No ambiguous mutations.** If issue resolution is ambiguous, stop and exit
+  cleanly. Do not guess.
+- **Verify every mutating command.** Parse the JSON output and confirm it shows
+  the intended effect before moving on.
+- **Treat comments as idempotent.** Before posting an audit comment, list
+  existing comments and skip posting if an identical marker comment already
+  exists.
+- **Project status updates are best-effort.** If the item is not on the project
+  board, log that fact and continue with labels/comments.
+- **Never throw on “no match found.”** Log and exit cleanly instead.
+
+Use marker prefixes in automation comments so reruns stay quiet:
+
+- `"[project-management:started]"`
+- `"[project-management:blocked]"`
+- `"[project-management:pr-title-warning]"`
+- `"[project-management:ready-for-merge-summary]"`
+
 ## Step 1: Resolve task to a work item
 
-Before doing anything else, determine the issue number from the available
-context. Work through the signals below **in order**, stopping as soon as
-one produces an unambiguous match.
-
-Read [`skills/github-admin/SKILL.md`](../github-admin/SKILL.md) for auth
-and configuration before running any commands.
-
----
+Determine the issue number from the available context. Work through the
+signals below **in order**, stopping only when one produces an unambiguous
+same-repository match.
 
 ### Signal 1 — direct issue number
 
 If the calling context includes an explicit issue number, use it immediately.
 Skip all remaining signals.
 
----
-
 ### Signal 2 — PR closing reference
 
-If a PR number is available, inspect its body and title for closing
-keywords (`Closes #N`, `Fixes #N`, `Resolves #N`). Extract N and use it.
+If a PR number is available, inspect its title and body for closing
+references. Only accept **same-repo** references of the form:
+
+- `Closes #N`
+- `Fixes #N`
+- `Resolves #N`
+
+Use `get-issue` because it returns PR title and body as JSON:
 
 ```bash
 node skills/github-admin/scripts/github-admin.mjs \
   get-issue --number <PR_NUMBER>
-# inspect the returned title and body for #N references
 ```
 
----
+Resolution rule:
+
+- If there is exactly one closing reference, use that issue number.
+- If there are zero closing references, continue to Signal 3.
+- If there are multiple closing references, log the candidates and exit
+  cleanly without mutating anything.
+
+Ignore plain mentions like `#123` that are not attached to a closing keyword.
+Ignore cross-repo references like `owner/repo#123`.
 
 ### Signal 3 — structured task ID
 
-If the task context contains a structured ID (e.g. `T2.7`, `T1.12`),
-search open issues for it. A structured ID is almost always unique.
+If the task context contains a structured ID such as `T2.7` or `T1.12`,
+search for it by title:
 
 ```bash
 node skills/github-admin/scripts/github-admin.mjs \
   list-issues --title-contains "<TASK_ID>" --state open
 ```
 
-If exactly one result, use it. If zero results, try `--state all` (the
-issue may already be closed).
+If zero results, retry with `--state all`.
 
----
+Resolution rule:
+
+- If exactly one result is returned, use it.
+- If multiple results are returned, keep only titles that contain the exact
+  task tag token.
+- If exactly one exact-tag result remains, use it.
+- Otherwise, log the candidates and exit cleanly without mutating anything.
 
 ### Signal 4 — branch name decoding
 
 If a branch name is available, extract a task ID from it:
 
 - Strip common prefixes: `task/`, `feature/`, `fix/`, `hotfix/`
-- Normalise separators: replace `_` and `-` with `.` in the task segment
-- Example: `task/T2_7` → `T2.7`
+- Normalize separators: replace `_` and `-` with `.` in the task segment
+- Example: `task/T2_7` -> `T2.7`
 
 Then apply Signal 3 with the extracted ID.
-
----
 
 ### Signal 5 — task name keyword search
 
@@ -90,16 +125,13 @@ node skills/github-admin/scripts/github-admin.mjs \
   list-issues --title-contains "<DISTINCTIVE_KEYWORD>" --state open
 ```
 
-Run narrower searches first; broaden only if zero results.
+Run narrow searches first; broaden only if zero results.
 
-**Disambiguation when multiple results are returned:**
+Resolution rule:
 
-1. Prefer the issue whose title contains the greatest number of words from the task name (case-insensitive).
-2. Among ties, prefer open over closed.
-3. Among remaining ties, take the lowest issue number.
-4. Log all candidates and the chosen one before proceeding.
-
----
+- If exactly one result remains, use it.
+- If multiple candidates remain at any point, log them and exit cleanly.
+- Do **not** auto-pick the lowest issue number as a tiebreaker.
 
 ### No match found
 
@@ -110,28 +142,51 @@ If all signals are exhausted without a match:
 
 ## Step 2: Act on the event
 
+For every mutating command below, inspect the JSON output before proceeding.
+
+### Shared verification rules
+
+Interpret command output like this:
+
+- `set-issue-status`: the returned `updatedIssues` array must contain the issue
+  number. If it does not, log that the issue is not on the project board and
+  continue with labels/comments.
+- `label-issue --action add`: verify the output contains the issue number and
+  the label set you intended to add.
+- `label-issue --action remove`: if the label is absent, suppress the error and
+  continue.
+- `update-issue`: verify the returned issue number matches the target item.
+- `comment-issue`: verify the returned comment id exists.
+- `link-pr-task`: verify the JSON fields `patchedBody` and `postedComment`; both
+  may be `false` on reruns and that is still success.
+
 ### `started` — work begins
 
 ```bash
-# 1. Set project status
+# 1. Set project status (best-effort)
 node skills/github-admin/scripts/github-admin.mjs \
   set-issue-status --issues <ISSUE_NUMBER> --status "In Progress"
 
-# 2. Remove blocked label if previously set (safe to fail)
+# 2. Remove blocked label if present (safe to fail)
 node skills/github-admin/scripts/github-admin.mjs \
   label-issue --action remove --number <ISSUE_NUMBER> --label blocked \
   2>/dev/null || true
 
-# 3. Comment with the branch being worked on
+# 3. Only post the started comment if it is not already present
+node skills/github-admin/scripts/github-admin.mjs \
+  issue-comment --action list --issue <ISSUE_NUMBER>
+
 node skills/github-admin/scripts/github-admin.mjs \
   comment-issue --number <ISSUE_NUMBER> \
-  --body "Work started on branch \`<BRANCH_NAME>\`."
+  --body "[project-management:started] Work started on branch \`<BRANCH_NAME>\`."
 ```
+
+Skip Step 3 when an identical marker comment already exists.
 
 ### `blocked` — work cannot proceed
 
 ```bash
-# 1. Set project status
+# 1. Set project status (best-effort)
 node skills/github-admin/scripts/github-admin.mjs \
   set-issue-status --issues <ISSUE_NUMBER> --status "Blocked"
 
@@ -139,15 +194,20 @@ node skills/github-admin/scripts/github-admin.mjs \
 node skills/github-admin/scripts/github-admin.mjs \
   label-issue --action add --number <ISSUE_NUMBER> --labels blocked
 
-# 3. Comment with the blocking reason
+# 3. Only post the blocked comment if it is not already present
+node skills/github-admin/scripts/github-admin.mjs \
+  issue-comment --action list --issue <ISSUE_NUMBER>
+
 node skills/github-admin/scripts/github-admin.mjs \
   comment-issue --number <ISSUE_NUMBER> \
-  --body "Blocked: <REASON>"
+  --body "[project-management:blocked] Blocked: <REASON>"
 ```
+
+Skip Step 3 when an identical marker comment already exists.
 
 ### `ready-for-merge` — PR is open, work is complete
 
-Run these steps in order. Each step is idempotent — re-running is safe.
+Run these steps in order.
 
 #### A. Fetch issue metadata
 
@@ -156,8 +216,11 @@ node skills/github-admin/scripts/github-admin.mjs \
   get-issue --number <ISSUE_NUMBER>
 ```
 
-Capture the output: `labels`, `milestone.number`, `assignees`. You will
-need these values in the steps below.
+Capture:
+
+- `labels`
+- `milestone.number`
+- `assignees`
 
 #### B. Set project board status
 
@@ -166,7 +229,9 @@ node skills/github-admin/scripts/github-admin.mjs \
   set-issue-status --issues <ISSUE_NUMBER> --status "Ready for Merge"
 ```
 
-#### C. Remove `blocked` label if present (safe to fail)
+If `updatedIssues` does not include the issue, log the miss and continue.
+
+#### C. Remove `blocked` label if present
 
 ```bash
 node skills/github-admin/scripts/github-admin.mjs \
@@ -176,8 +241,8 @@ node skills/github-admin/scripts/github-admin.mjs \
 
 #### D. Link PR to issue
 
-Adds `Closes #<ISSUE_NUMBER>` to the PR body and posts a linked-PR comment
-on the issue so the connection is visible from both sides:
+`link-pr-task` is rerun-safe. It only patches the PR body or posts the linked
+PR comment when they are missing.
 
 ```bash
 node skills/github-admin/scripts/github-admin.mjs \
@@ -187,21 +252,19 @@ node skills/github-admin/scripts/github-admin.mjs \
 #### E. Mirror issue labels onto the PR
 
 GitHub does not automatically copy labels from an issue to its PR.
-Apply all labels from the issue to the PR so both show the same
-classification (component, priority, type). Filter out `blocked` if it was
-present in Step A, since the PR should not be marked as blocked.
+Apply all issue labels to the PR except `blocked`.
 
 ```bash
 node skills/github-admin/scripts/github-admin.mjs \
   label-issue --action add --number <PR_NUMBER> \
-  --labels <COMMA_SEPARATED_ISSUE_LABELS>
+  --labels <COMMA_SEPARATED_ISSUE_LABELS_EXCEPT_BLOCKED>
 ```
 
-Skip this step if the issue has no labels.
+Skip this step if the filtered label set is empty.
 
 #### F. Mirror issue milestone onto the PR
 
-GitHub treats PRs as issues for milestone purposes. Copy the milestone:
+GitHub treats PRs as issues for milestone purposes.
 
 ```bash
 node skills/github-admin/scripts/github-admin.mjs \
@@ -212,8 +275,6 @@ Skip this step if the issue has no milestone.
 
 #### G. Mirror issue assignees onto the PR
 
-Copy the assignees from the issue to the PR to maintain ownership tracking:
-
 ```bash
 node skills/github-admin/scripts/github-admin.mjs \
   update-issue --number <PR_NUMBER> --assignees <COMMA_SEPARATED_ISSUE_ASSIGNEES>
@@ -223,43 +284,78 @@ Skip this step if the issue has no assignees.
 
 #### H. Verify PR title references the task
 
-Read the PR title. If it does not reference the task ID or the issue
-number, post a warning comment on the PR:
+Read the PR title from `get-issue --number <PR_NUMBER>`. If the title does not
+reference either the task tag or `#<ISSUE_NUMBER>`, warn once.
 
 ```bash
 node skills/github-admin/scripts/github-admin.mjs \
+  issue-comment --action list --issue <PR_NUMBER>
+
+node skills/github-admin/scripts/github-admin.mjs \
   comment-issue --number <PR_NUMBER> \
-  --body "⚠️ PR title does not reference the task or issue. Consider updating it to make the connection explicit."
+  --body "[project-management:pr-title-warning] PR title does not reference the task or issue. Consider updating it to make the connection explicit."
 ```
 
-Only post this warning if the title is genuinely missing the reference.
+Only post the warning if:
+
+- the title genuinely lacks the reference
+- no identical marker warning comment already exists
 
 #### I. Post implementation summary on the issue
 
+List existing comments first, then post only if the exact marker comment does
+not already exist:
+
 ```bash
 node skills/github-admin/scripts/github-admin.mjs \
-  comment-issue --number <ISSUE_NUMBER> --body "<SUMMARY>"
+  issue-comment --action list --issue <ISSUE_NUMBER>
+
+node skills/github-admin/scripts/github-admin.mjs \
+  comment-issue --number <ISSUE_NUMBER> \
+  --body "[project-management:ready-for-merge-summary] <SUMMARY>"
 ```
 
-The summary should cover: what changed, how it was tested, any known
-limitations or follow-up items.
+The summary should cover:
+
+- what changed
+- how it was tested
+- any known limitations or follow-up items
 
 ### `done` — PR merged or task closed manually
 
 ```bash
-# 1. Set project status
+# 1. Set project status (best-effort)
 node skills/github-admin/scripts/github-admin.mjs \
   set-issue-status --issues <ISSUE_NUMBER> --status "Done"
 
-# 2. Close the issue if not already closed by the merge
+# 2. Remove blocked label if present (safe to fail)
+node skills/github-admin/scripts/github-admin.mjs \
+  label-issue --action remove --number <ISSUE_NUMBER> --label blocked \
+  2>/dev/null || true
+
+# 3. Close the issue if not already closed by the merge
 node skills/github-admin/scripts/github-admin.mjs \
   update-issue --number <ISSUE_NUMBER> --state closed
 ```
 
+## Required subagent output
+
+At the end of the skill run, report back:
+
+- resolved issue number, or `none`
+- which resolution signal matched
+- every command executed
+- whether project status updated, or was skipped because the item was off-board
+- whether each comment was posted or skipped as a rerun duplicate
+- any ambiguity or roadblock encountered
+
 ## Error handling
 
 - **No work item found** — exit gracefully with a log message; never error.
-- **Item not in project board** — skip `set-issue-status`; still post the comment.
-- **Status already correct** — `set-issue-status` is idempotent; no action needed.
+- **Ambiguous work item resolution** — log candidates and exit gracefully with
+  no mutations.
+- **Item not in project board** — skip board status updates; still perform
+  labels/comments.
+- **Status already correct** — `set-issue-status` is effectively idempotent.
 - **Label not present on remove** — suppress the error (`2>/dev/null || true`).
-- **Never skip the comment step** — it provides an audit trail even when board status is unchanged.
+- **Duplicate marker comment** — skip posting; do not create comment spam.

--- a/skills/project-management/SKILL.md
+++ b/skills/project-management/SKILL.md
@@ -25,23 +25,88 @@ resolves the work item and acts on it.
 
 ## Step 1: Resolve task to a work item
 
-Before doing anything else, determine the issue number from the context provided.
-
-**If an issue number was given directly** — use it.
-
-**Otherwise, search by task ID or name:**
-
-```bash
-node skills/github-admin/scripts/github-admin.mjs \
-  list-issues --title-contains "<TASK_ID_OR_NAME>" --state open
-```
-
-Pick the issue whose title best matches the task. If no match is found,
-**exit gracefully** — log "No work item found for task <TASK>; skipping
-project management." and stop. Do not error.
+Before doing anything else, determine the issue number from the available
+context. Work through the signals below **in order**, stopping as soon as
+one produces an unambiguous match.
 
 Read [`skills/github-admin/SKILL.md`](../github-admin/SKILL.md) for auth
 and configuration before running any commands.
+
+---
+
+### Signal 1 — direct issue number
+
+If the calling context includes an explicit issue number, use it immediately.
+Skip all remaining signals.
+
+---
+
+### Signal 2 — PR closing reference
+
+If a PR number is available, inspect the PR body and title for closing
+keywords (`Closes #N`, `Fixes #N`, `Resolves #N`). Extract N and use it.
+
+```bash
+node skills/github-admin/scripts/github-admin.mjs \
+  list-prs --state open
+# find the PR by number and read its body for #N references
+```
+
+---
+
+### Signal 3 — structured task ID
+
+If the task context contains a structured ID (e.g. `T2.7`, `T1.12`),
+search open issues for it. A structured ID is almost always unique.
+
+```bash
+node skills/github-admin/scripts/github-admin.mjs \
+  list-issues --title-contains "<TASK_ID>" --state open
+```
+
+If exactly one result, use it. If zero results, try `--state all` (the
+issue may already be closed).
+
+---
+
+### Signal 4 — branch name decoding
+
+If a branch name is available, extract a task ID from it:
+
+- Strip common prefixes: `task/`, `feature/`, `fix/`, `hotfix/`
+- Normalise separators: replace `_` and `-` with `.` in the task segment
+- Example: `task/T2_7` → `T2.7`
+
+Then apply Signal 3 with the extracted ID.
+
+---
+
+### Signal 5 — task name keyword search
+
+Search by the most distinctive words from the task name or description:
+
+```bash
+node skills/github-admin/scripts/github-admin.mjs \
+  list-issues --title-contains "<DISTINCTIVE_KEYWORD>" --state open
+```
+
+Run narrower searches first; broaden only if zero results.
+
+**Disambiguation when multiple results are returned:**
+
+1. Prefer the issue whose title contains the greatest number of words from the task name (case-insensitive).
+2. Among ties, prefer open over closed.
+3. Among remaining ties, take the lowest issue number.
+4. Log all candidates and the chosen one before proceeding.
+
+---
+
+### No match found
+
+If all signals are exhausted without a match:
+
+- Log: `No work item found for task '<TASK>'; skipping project management.`
+- Exit cleanly. Do not error or throw.
 
 ## Step 2: Act on the event
 

--- a/skills/project-management/SKILL.md
+++ b/skills/project-management/SKILL.md
@@ -43,13 +43,13 @@ Skip all remaining signals.
 
 ### Signal 2 — PR closing reference
 
-If a PR number is available, inspect the PR body and title for closing
+If a PR number is available, inspect its body and title for closing
 keywords (`Closes #N`, `Fixes #N`, `Resolves #N`). Extract N and use it.
 
 ```bash
 node skills/github-admin/scripts/github-admin.mjs \
-  list-prs --state open
-# find the PR by number and read its body for #N references
+  get-issue --number <PR_NUMBER>
+# inspect the returned title and body for #N references
 ```
 
 ---
@@ -188,7 +188,8 @@ node skills/github-admin/scripts/github-admin.mjs \
 
 GitHub does not automatically copy labels from an issue to its PR.
 Apply all labels from the issue to the PR so both show the same
-classification (component, priority, type):
+classification (component, priority, type). Filter out `blocked` if it was
+present in Step A, since the PR should not be marked as blocked.
 
 ```bash
 node skills/github-admin/scripts/github-admin.mjs \
@@ -209,7 +210,18 @@ node skills/github-admin/scripts/github-admin.mjs \
 
 Skip this step if the issue has no milestone.
 
-#### G. Verify PR title references the task
+#### G. Mirror issue assignees onto the PR
+
+Copy the assignees from the issue to the PR to maintain ownership tracking:
+
+```bash
+node skills/github-admin/scripts/github-admin.mjs \
+  update-issue --number <PR_NUMBER> --assignees <COMMA_SEPARATED_ISSUE_ASSIGNEES>
+```
+
+Skip this step if the issue has no assignees.
+
+#### H. Verify PR title references the task
 
 Read the PR title. If it does not reference the task ID or the issue
 number, post a warning comment on the PR:
@@ -222,7 +234,7 @@ node skills/github-admin/scripts/github-admin.mjs \
 
 Only post this warning if the title is genuinely missing the reference.
 
-#### H. Post implementation summary on the issue
+#### I. Post implementation summary on the issue
 
 ```bash
 node skills/github-admin/scripts/github-admin.mjs \


### PR DESCRIPTION
## Summary

- Introduces `skills/github-admin/` as a structured skill: `SKILL.md` entry point, `reference.md` index, and 24 per-command docs under `references/commands/`
- Moves the script from `scripts/github-admin.mjs` to `skills/github-admin/scripts/github-admin.mjs`; updates `package.json` and `scripts/verify-live.mjs` paths
- Adds `.cursor/skills/github-admin` symlink so agents load the skill automatically
- All commands are now **generic** — no POC-specific commands, hardcoded title filters, or one-off automation remain
  - `poc-live` renamed to `project` (`--action link-prs [--title-prefix] | close-project`)
  - Removed: `assign-poc`, `remap-poc-milestones`, `set-project-status-workflow`, `reconcile-poc-doc`, `close-implemented`, `complete-issue`, `complete-t0`
  - Removed all legacy alias commands and their docs; only the preferred grouped forms remain
  - Internal helpers renamed to drop legacy naming (e.g. `listIssueComments` → `listComments`)
- `AGENTS.md` and `AGENTS_WORKFLOW.md` updated to prefer the skill over ad hoc scripts

## Test plan

- [x] `node skills/github-admin/scripts/github-admin.mjs help` exits 0 and lists all 24 commands
- [x] Removed commands (`assign-poc`, `remap-poc-milestones`, etc.) throw `Unknown command`
- [x] No stale POC-specific references in docs or script
- [x] All 24 commands have a matching doc file and `reference.md` entry